### PR TITLE
Improve mirroring reliability and add ADB power/reboot controls

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,9 +26,9 @@ android {
 
         targetSdkVersion 31
 
-        versionCode 31
+        versionCode 32
 
-        versionName "1.5.18"
+        versionName "1.5.19"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,9 +26,9 @@ android {
 
         targetSdkVersion 31
 
-        versionCode 29
+        versionCode 31
 
-        versionName "1.5.16"
+        versionName "1.5.18"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,9 +26,9 @@ android {
 
         targetSdkVersion 31
 
-        versionCode 32
+        versionCode 33
 
-        versionName "1.5.19"
+        versionName "1.5.20"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,9 +26,9 @@ android {
 
         targetSdkVersion 31
 
-        versionCode 25
+        versionCode 29
 
-        versionName "1.5.12"
+        versionName "1.5.16"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,63 +1,141 @@
 evaluationDependsOn(':server')
 
+
+
 apply plugin: 'com.android.application'
 
+
+
 android {
+
     namespace 'org.client.scrcpy'
+
     flavorDimensions = ["default"]
 
+
+
     compileSdkVersion 31
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 31
-        versionCode 14
-        versionName "1.5.1"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        setProperty("archivesBaseName", "scrcpy")
+
+    buildFeatures {
+        buildConfig true
     }
+
+    defaultConfig {
+
+        minSdkVersion 21
+
+        targetSdkVersion 31
+
+        versionCode 25
+
+        versionName "1.5.12"
+
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+
+    }
+
     signingConfigs {
+
         release {
+
             storeFile file("scrcpy.jks")
 
+
+
             def properties = new Properties()
+
             if (file("../local.properties").exists()) {
+
                 file("../local.properties").withInputStream { stream ->
+
                     properties.load(stream)
+
                 }
+
             }
+
+
 
             storePassword System.getenv("SIGNING_STORE_PASSWORD") ?: properties.getProperty("SIGNING_STORE_PASSWORD")
+
             keyAlias System.getenv("SIGNING_KEY_ALIAS") ?: properties.getProperty("SIGNING_KEY_ALIAS")
+
             keyPassword System.getenv("SIGNING_KEY_PASSWORD") ?: properties.getProperty("SIGNING_KEY_PASSWORD")
+
         }
+
     }
+
+
 
     buildTypes {
+
         release {
+
             minifyEnabled false
+
             if (file("scrcpy.jks").exists()) {
+
                 signingConfig signingConfigs.release
+
             }
+
         }
+
     }
 
+
+
     productFlavors {
+
         scrcpy {
+
             applicationId "org.client.scrcpy"
+
         }
+
     }
+
+
+
 
 
     tasks.whenTaskAdded { task ->
+
         def buildType = gradle.startParameter.taskNames.any { it.endsWith('Release') } ? 'Release' : 'Debug'
 
+
+
         task.dependsOn ":server:assemble${buildType}"
+
         task.dependsOn ":server:copyServer"
+
     }
+
+
+
+    applicationVariants.all { variant ->
+
+        variant.outputs.all { output ->
+
+            outputFileName = "scrcpy-${variant.versionName}-r${variant.versionCode}-${variant.buildType.name}.apk"
+
+        }
+
+    }
+
 }
 
+
+
 dependencies {
+
     testImplementation 'junit:junit:4.13.2'
+
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
+
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+
 }
+
+

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,13 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.SEND" />
+            <data android:mimeType="text/plain" />
+        </intent>
+    </queries>
+
     <application
         android:name=".App"
         android:allowBackup="true"
@@ -24,6 +31,12 @@
             android:enabled="true"
             android:exported="true" />
         <service android:name=".FloatService" />
+
+        <provider
+            android:name=".LogFileProvider"
+            android:authorities="${applicationId}.log"
+            android:exported="false"
+            android:grantUriPermissions="true" />
     </application>
 
 </manifest>

--- a/app/src/main/java/org/client/scrcpy/App.java
+++ b/app/src/main/java/org/client/scrcpy/App.java
@@ -11,6 +11,7 @@ import android.util.Log;
 import org.client.scrcpy.utils.AdbHelper;
 import org.client.scrcpy.utils.ExecUtil;
 import org.client.scrcpy.utils.PreUtils;
+import org.client.scrcpy.utils.SessionLog;
 import org.client.scrcpy.utils.ThreadUtils;
 
 import java.util.HashMap;
@@ -29,6 +30,7 @@ public class App extends Application implements Application.ActivityLifecycleCal
         super.onCreate();
         init();  // 初始化id 数据
         AdbHelper.startAdbServer();
+        SessionLog.resetAndStart(this);
     }
 
     @Override

--- a/app/src/main/java/org/client/scrcpy/Constant.java
+++ b/app/src/main/java/org/client/scrcpy/Constant.java
@@ -11,6 +11,9 @@ public class Constant {
     public static final String PREFERENCE_SPINNER_RESOLUTION = "spinner_resolution";
     public static final String PREFERENCE_SPINNER_BITRATE = "spinner_bitrate";
 
+  /** Index of the "Auto" entry in {@code options_resolution_values}. */
+    public static final int RESOLUTION_AUTO_INDEX = 0;
+
     public static final String PREFERENCE_SPINNER_DELAY = "delay_control";
 
     public static final String HISTORY_LIST_KEY = "history_list_key";

--- a/app/src/main/java/org/client/scrcpy/Constant.java
+++ b/app/src/main/java/org/client/scrcpy/Constant.java
@@ -15,6 +15,9 @@ public class Constant {
     public static final int RESOLUTION_AUTO_INDEX = 0;
 
     public static final String PREFERENCE_SPINNER_DELAY = "delay_control";
+    public static final String PREFERENCE_SPINNER_CODEC = "spinner_video_codec";
+    public static final String PREFERENCE_SPINNER_FPS = "spinner_video_fps";
+    public static final String PREFERENCE_VIDEO_ENCODER = "video_encoder";
 
     public static final String HISTORY_LIST_KEY = "history_list_key";
     public static final String USER_ID = "user_id";

--- a/app/src/main/java/org/client/scrcpy/LogFileProvider.java
+++ b/app/src/main/java/org/client/scrcpy/LogFileProvider.java
@@ -1,0 +1,74 @@
+package org.client.scrcpy;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+import android.provider.OpenableColumns;
+
+import org.client.scrcpy.utils.SessionLog;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+public class LogFileProvider extends ContentProvider {
+
+    @Override
+    public boolean onCreate() {
+        return true;
+    }
+
+    @Override
+    public ParcelFileDescriptor openFile(Uri uri, String mode) throws FileNotFoundException {
+        File file = SessionLog.getFile();
+        if (file == null || !file.exists()) {
+            throw new FileNotFoundException("session.log");
+        }
+        return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY);
+    }
+
+    @Override
+    public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+        File file = SessionLog.getFile();
+        if (file == null || !file.exists()) {
+            return null;
+        }
+        String[] columns = projection != null ? projection
+                : new String[]{OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE};
+        MatrixCursor cursor = new MatrixCursor(columns);
+        Object[] row = new Object[columns.length];
+        for (int i = 0; i < columns.length; i++) {
+            if (OpenableColumns.DISPLAY_NAME.equals(columns[i])) {
+                row[i] = "scrcpy-session.log";
+            } else if (OpenableColumns.SIZE.equals(columns[i])) {
+                row[i] = file.length();
+            } else {
+                row[i] = null;
+            }
+        }
+        cursor.addRow(row);
+        return cursor;
+    }
+
+    @Override
+    public String getType(Uri uri) {
+        return "text/plain";
+    }
+
+    @Override
+    public Uri insert(Uri uri, ContentValues values) {
+        return null;
+    }
+
+    @Override
+    public int delete(Uri uri, String selection, String[] selectionArgs) {
+        return 0;
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+        return 0;
+    }
+}

--- a/app/src/main/java/org/client/scrcpy/MainActivity.java
+++ b/app/src/main/java/org/client/scrcpy/MainActivity.java
@@ -25,6 +25,7 @@ import android.util.Log;
 import android.view.Display;
 import android.view.KeyEvent;
 import android.view.Surface;
+import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewConfiguration;
@@ -75,6 +76,8 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
     private String serverAdr = null;
     private SurfaceView surfaceView;
     private Surface surface;
+    private SurfaceHolder.Callback surfaceCallback;
+    private boolean scrcpyServiceStarted = false;
     private Scrcpy scrcpy;
     private long timestamp = 0;
 
@@ -147,11 +150,14 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
         } catch (Exception e) {
             e.printStackTrace();
         }
+        if (surfaceView != null && surfaceCallback != null) {
+            surfaceView.getHolder().removeCallback(surfaceCallback);
+            surfaceView = null;
+        }
+        scrcpyServiceStarted = false;
+        surfaceCallback = null;
         if (surface != null) {
             surface = null;
-        }
-        if (surfaceView != null) {
-            surfaceView = null;
         }
         serviceBound = false;
         scrcpy_main();
@@ -168,6 +174,7 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         this.context = this;
+        setTitle(getString(R.string.app_name));
         if (savedInstanceState != null) {
             first_time = savedInstanceState.getBoolean("first_time");
             landscape = savedInstanceState.getBoolean("landscape");
@@ -550,6 +557,16 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
         screenWidth = temp;
     }
 
+    private boolean isSurfaceReady(Surface displaySurface) {
+        if (displaySurface == null) {
+            return false;
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            return displaySurface.isValid();
+        }
+        return true;
+    }
+
     @SuppressLint("ClickableViewAccessibility")
     private void start_screen_copy_magic() {
         setContentView(R.layout.surface);
@@ -562,7 +579,31 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
                         | View.SYSTEM_UI_FLAG_FULLSCREEN
                         | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
         surfaceView = findViewById(R.id.decoder_surface);
-        surface = surfaceView.getHolder().getSurface();
+        scrcpyServiceStarted = false;
+        surfaceCallback = new SurfaceHolder.Callback() {
+            @Override
+            public void surfaceCreated(SurfaceHolder holder) {
+                surface = holder.getSurface();
+                if (!scrcpyServiceStarted) {
+                    scrcpyServiceStarted = true;
+                    start_Scrcpy_service();
+                }
+            }
+
+            @Override
+            public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
+                surface = holder.getSurface();
+                if (serviceBound && scrcpy != null && isSurfaceReady(surface)) {
+                    scrcpy.setParms(surface, screenWidth, screenHeight);
+                }
+            }
+
+            @Override
+            public void surfaceDestroyed(SurfaceHolder holder) {
+                surface = null;
+            }
+        };
+        surfaceView.getHolder().addCallback(surfaceCallback);
         final LinearLayout nav_bar = findViewById(R.id.nav_button_bar);
         if (PreUtils.get(context, Constant.CONTROL_NAV, false) &&
                 !PreUtils.get(context, Constant.CONTROL_NO, false)) {
@@ -663,8 +704,13 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
                             | View.SYSTEM_UI_FLAG_FULLSCREEN
                             | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
             if (serviceBound) {
-                // 黑屏无需修复， 因为只是自带的配置问题
-                linearLayout = findViewById(R.id.container1);
+                if (surfaceView != null) {
+                    Surface currentSurface = surfaceView.getHolder().getSurface();
+                    if (isSurfaceReady(currentSurface)) {
+                        surface = currentSurface;
+                        scrcpy.setParms(surface, screenWidth, screenHeight);
+                    }
+                }
                 scrcpy.resume();
             }
         }

--- a/app/src/main/java/org/client/scrcpy/MainActivity.java
+++ b/app/src/main/java/org/client/scrcpy/MainActivity.java
@@ -46,6 +46,7 @@ import android.widget.Toast;
 import org.client.scrcpy.utils.AdbHelper;
 import org.client.scrcpy.utils.PreUtils;
 import org.client.scrcpy.utils.Progress;
+import org.client.scrcpy.utils.ResolutionHelper;
 import org.client.scrcpy.utils.ThreadUtils;
 import org.client.scrcpy.utils.Util;
 import org.json.JSONArray;
@@ -82,6 +83,9 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
     private long timestamp = 0;
 
     private LinearLayout linearLayout;
+
+    private boolean autoResolutionEnabled = false;
+    private ResolutionHelper.LimitSource resolutionLimitSource = null;
 
     private final ServiceConnection serviceConnection = new ServiceConnection() {
         @Override
@@ -279,6 +283,12 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
             showListPopulWindow(editText);
         });
 
+        editText.setOnFocusChangeListener((v, hasFocus) -> {
+            if (!hasFocus) {
+                updateResolutionPreview();
+            }
+        });
+
         // 无头模式，实际上要隐藏掉所有控件，否则会被显示出 ip 地址
         if (headlessMode) {
             if (scrollView != null) {
@@ -348,9 +358,9 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
         aSwitch1.setChecked(PreUtils.get(context, Constant.CONTROL_NAV, false));
         audioForwardSwitch.setChecked(PreUtils.get(context, Constant.AUDIO_FORWARD, true));
 
-        setSpinner(R.array.options_resolution_values, R.id.spinner_video_resolution, Constant.PREFERENCE_SPINNER_RESOLUTION);
         setSpinner(R.array.options_bitrate_keys, R.id.spinner_video_bitrate, Constant.PREFERENCE_SPINNER_BITRATE);
         setSpinner(R.array.options_delay_keys, R.id.delay_control_spinner, Constant.PREFERENCE_SPINNER_DELAY);
+        setupResolutionSpinner();
         if (aSwitch0.isChecked()) {
             aSwitch1.setClickable(false);
             aSwitch1.setTextColor(Color.GRAY);
@@ -469,6 +479,105 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
         }
     }
 
+    private void setupResolutionSpinner() {
+        final Spinner spinner = findViewById(R.id.spinner_video_resolution);
+        spinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                PreUtils.put(context, Constant.PREFERENCE_SPINNER_RESOLUTION, position);
+                updateResolutionPreview();
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+                PreUtils.put(context, Constant.PREFERENCE_SPINNER_RESOLUTION, 0);
+            }
+        });
+        int selection = PreUtils.get(context, Constant.PREFERENCE_SPINNER_RESOLUTION, 0);
+        if (selection < spinner.getCount()) {
+            spinner.setSelection(selection);
+        } else {
+            spinner.setSelection(0);
+        }
+        updateResolutionPreview();
+    }
+
+    private void updateResolutionPreview() {
+        TextView info = findViewById(R.id.text_resolution_info);
+        Spinner spinner = findViewById(R.id.spinner_video_resolution);
+        if (info == null || spinner == null) {
+            return;
+        }
+        if (spinner.getSelectedItemPosition() != Constant.RESOLUTION_AUTO_INDEX) {
+            info.setVisibility(View.GONE);
+            return;
+        }
+        EditText editText = findViewById(R.id.editText_server_host);
+        String remoteAdr = editText != null ? editText.getText().toString().trim() : "";
+        if (TextUtils.isEmpty(remoteAdr)) {
+            info.setText(R.string.resolution_auto_need_ip);
+            info.setVisibility(View.VISIBLE);
+            return;
+        }
+        info.setText(R.string.resolution_auto_detecting);
+        info.setVisibility(View.VISIBLE);
+        ThreadUtils.workPost(() -> {
+            try {
+                ResolutionHelper.AutoResolution autoResolution =
+                        ResolutionHelper.computeAuto(context, remoteAdr);
+                final String message = formatResolutionMessage(autoResolution, false);
+                ThreadUtils.post(() -> {
+                    if (!isFinishing()) {
+                        updateResolutionInfoText(message);
+                    }
+                });
+            } catch (Exception e) {
+                Log.e("Scrcpy", "Resolution preview failed: " + e.getMessage());
+                ThreadUtils.post(() -> {
+                    if (!isFinishing()) {
+                        info.setText(R.string.resolution_auto_failed);
+                        info.setVisibility(View.VISIBLE);
+                    }
+                });
+            }
+        });
+    }
+
+    private void updateResolutionInfoText(String message) {
+        TextView info = findViewById(R.id.text_resolution_info);
+        if (info == null) {
+            return;
+        }
+        if (TextUtils.isEmpty(message)) {
+            info.setVisibility(View.GONE);
+            return;
+        }
+        info.setText(message);
+        info.setVisibility(View.VISIBLE);
+    }
+
+    private String formatResolutionMessage(ResolutionHelper.AutoResolution autoResolution, boolean activeStream) {
+        if (autoResolution.limitSource == ResolutionHelper.LimitSource.LOCAL) {
+            return getString(activeStream ? R.string.resolution_auto_stream_local : R.string.resolution_auto_local,
+                    autoResolution.displayWidth, autoResolution.displayHeight);
+        }
+        return getString(activeStream ? R.string.resolution_auto_stream_remote : R.string.resolution_auto_remote,
+                autoResolution.displayWidth, autoResolution.displayHeight);
+    }
+
+    private String formatActiveStreamResolutionMessage() {
+        return formatResolutionMessage(
+                new ResolutionHelper.AutoResolution(
+                        Math.max(screenWidth, screenHeight),
+                        screenWidth,
+                        screenHeight,
+                        ResolutionHelper.getLocalMaxDimension(context),
+                        screenWidth,
+                        screenHeight,
+                        resolutionLimitSource),
+                true);
+    }
+
     private void getAttributes() {
 
         final EditText editTextServerHost = findViewById(R.id.editText_server_host);
@@ -491,8 +600,12 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
         PreUtils.put(context, Constant.AUDIO_FORWARD, audioEnableSwitch.isChecked());
 
         final String[] videoResolutions = getResources().getStringArray(R.array.options_resolution_values)[videoResolutionSpinner.getSelectedItemPosition()].split("x");
-        screenHeight = Integer.parseInt(videoResolutions[0]);
-        screenWidth = Integer.parseInt(videoResolutions[1]);
+        autoResolutionEnabled = videoResolutionSpinner.getSelectedItemPosition() == Constant.RESOLUTION_AUTO_INDEX;
+        resolutionLimitSource = null;
+        if (!autoResolutionEnabled) {
+            screenHeight = Integer.parseInt(videoResolutions[0]);
+            screenWidth = Integer.parseInt(videoResolutions[1]);
+        }
         videoBitrate = getResources().getIntArray(R.array.options_bitrate_values)[videoBitrateSpinner.getSelectedItemPosition()];
         delayControl = getResources().getIntArray(R.array.options_delay_values)[delayControlSpinner.getSelectedItemPosition()];
     }
@@ -843,6 +956,15 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
             Progress.showDialog(MainActivity.this, getString(R.string.please_wait));
             ThreadUtils.workPost(() -> {
                 AdbHelper.writeAssetsJarServer(App.mContext);
+                if (autoResolutionEnabled) {
+                    ResolutionHelper.AutoResolution autoResolution =
+                            ResolutionHelper.computeAuto(context, serverAdr);
+                    screenWidth = autoResolution.displayWidth;
+                    screenHeight = autoResolution.displayHeight;
+                    resolutionLimitSource = autoResolution.limitSource;
+                    final String resolutionMessage = formatResolutionMessage(autoResolution, false);
+                    ThreadUtils.post(() -> updateResolutionInfoText(resolutionMessage));
+                }
                 SendCommands.CmdStatus sendStatus = sendCommands.SendAdbCommands(context, serverHost,
                         serverPort,
                         localForwardPort,
@@ -874,6 +996,9 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
      */
     protected void connectSuccessExt() {
         Dialog.closeDialogs();
+        if (autoResolutionEnabled && resolutionLimitSource != null) {
+            Toast.makeText(context, formatActiveStreamResolutionMessage(), Toast.LENGTH_LONG).show();
+        }
     }
 
     protected void connectExitExt() {

--- a/app/src/main/java/org/client/scrcpy/MainActivity.java
+++ b/app/src/main/java/org/client/scrcpy/MainActivity.java
@@ -126,15 +126,15 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
                             Toast.makeText(context, "Connection Timed out 2", Toast.LENGTH_SHORT).show();
                         } else {
                             first_time = false;
-                            // 连接成功后，再把按钮显示出来
-                            set_display_nd_touch();
+                            applyClientOrientationFromRemote();
+                            refreshMirrorLayout();
                             connectSuccessExt();
                         }
                     });
                 });
             } else {
                 scrcpy.setParms(surface, screenWidth, screenHeight);
-                set_display_nd_touch();
+                refreshMirrorLayout();
                 connectSuccessExt();
             }
             // set_display_nd_touch();
@@ -444,6 +444,9 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
 //        float this_dev_height = metrics.heightPixels;
 //        float this_dev_width = metrics.widthPixels;
 
+        if (linearLayout == null || surfaceView == null || scrcpy == null) {
+            return;
+        }
         float this_dev_height = linearLayout.getHeight();
         float this_dev_width = linearLayout.getWidth();
         if (PreUtils.get(context, Constant.CONTROL_NAV, false) &&
@@ -733,6 +736,27 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
                 != Configuration.ORIENTATION_PORTRAIT;
     }
 
+    @SuppressLint("SourceLockedOrientationActivity")
+    private void applyClientOrientationFromRemote() {
+        if (scrcpy == null) {
+            return;
+        }
+        int[] remote = scrcpy.getOrientedRemoteSize(landscape);
+        if (remote[0] <= 0 || remote[1] <= 0) {
+            return;
+        }
+        boolean remoteLandscape = remote[0] > remote[1];
+        landscape = remoteLandscape;
+        result_of_Rotation = true;
+        Log.i("Scrcpy", "Client orientation from remote " + remote[0] + "x" + remote[1]
+                + " landscape=" + remoteLandscape);
+        if (remoteLandscape) {
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
+        } else {
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
+        }
+    }
+
     private void applyMirrorImmersiveMode() {
         final View decorView = getWindow().getDecorView();
         decorView.setSystemUiVisibility(
@@ -863,21 +887,12 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
         bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE);
     }
 
-    @SuppressLint("SourceLockedOrientationActivity")
     @Override
     public void loadNewRotation() {
         ThreadUtils.post(() -> {
-            if (first_time) {
-                first_time = false;
-            }
             result_of_Rotation = true;
-            landscape = !landscape;
-            swapDimensions();
-            if (landscape) {
-                setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
-            } else {
-                setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
-            }
+            applyClientOrientationFromRemote();
+            refreshMirrorLayout();
         });
     }
 

--- a/app/src/main/java/org/client/scrcpy/MainActivity.java
+++ b/app/src/main/java/org/client/scrcpy/MainActivity.java
@@ -290,6 +290,10 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
         if (rebootButton != null) {
             rebootButton.setOnClickListener(v -> confirmRebootRemoteDevice());
         }
+        Button powerOffButton = findViewById(R.id.button_power_off);
+        if (powerOffButton != null) {
+            powerOffButton.setOnClickListener(v -> confirmPowerOffRemoteDevice());
+        }
         Button shareLogButton = findViewById(R.id.button_share_log);
         if (shareLogButton != null) {
             shareLogButton.setOnClickListener(v -> shareSessionLog());
@@ -1089,6 +1093,39 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
                     return;
                 }
                 Toast.makeText(context, getString(R.string.reboot_sent, device), Toast.LENGTH_SHORT).show();
+                startStatusMonitor();
+            });
+        });
+    }
+
+    private void confirmPowerOffRemoteDevice() {
+        getAttributes();
+        if (TextUtils.isEmpty(serverAdr)) {
+            Toast.makeText(context, "Server Address Empty", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        String[] serverInfo = Util.getServerHostAndPort(serverAdr);
+        String device = serverInfo[0] + ":" + serverInfo[1];
+        Dialog.displayDialog(this,
+                getString(R.string.power_off_title),
+                getString(R.string.power_off_ask, device),
+                () -> powerOffRemoteDevice(device),
+                () -> {
+                });
+    }
+
+    private void powerOffRemoteDevice(String device) {
+        Progress.showDialog(MainActivity.this, getString(R.string.power_off_wait));
+        ThreadUtils.workPost(() -> {
+            AdbHelper.adbCmd(App.mContext, "connect", device);
+            String result = AdbHelper.adbCmd(App.mContext, "-s", device, "reboot", "-p");
+            SessionLog.i("ADB power off device=" + device + " result=" + result);
+            ThreadUtils.post(() -> {
+                Progress.closeDialog();
+                if (MainActivity.this.isFinishing()) {
+                    return;
+                }
+                Toast.makeText(context, getString(R.string.power_off_sent, device), Toast.LENGTH_SHORT).show();
                 startStatusMonitor();
             });
         });

--- a/app/src/main/java/org/client/scrcpy/MainActivity.java
+++ b/app/src/main/java/org/client/scrcpy/MainActivity.java
@@ -10,6 +10,8 @@ import android.content.ServiceConnection;
 import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
 import android.graphics.Color;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
@@ -19,7 +21,9 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.os.SystemClock;
+import android.text.Editable;
 import android.text.TextUtils;
+import android.text.TextWatcher;
 import android.transition.AutoTransition;
 import android.transition.TransitionManager;
 import android.util.DisplayMetrics;
@@ -92,6 +96,9 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
 
     private boolean autoResolutionEnabled = false;
     private ResolutionHelper.LimitSource resolutionLimitSource = null;
+
+    private volatile boolean statusMonitorActive = false;
+    private volatile int statusCheckGeneration = 0;
 
     private final ServiceConnection serviceConnection = new ServiceConnection() {
         @Override
@@ -269,6 +276,7 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
         sendCommands = new SendCommands();
 
         startButton.setOnClickListener(v -> {
+            stopStatusMonitor();
             getAttributes();
             SessionLog.i("Start clicked host=" + serverAdr
                     + " max=" + Math.max(screenHeight, screenWidth)
@@ -278,6 +286,10 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
                     + " fps=" + videoFrameRate);
             connectScrcpyServer(serverAdr);
         });
+        Button rebootButton = findViewById(R.id.button_reboot);
+        if (rebootButton != null) {
+            rebootButton.setOnClickListener(v -> confirmRebootRemoteDevice());
+        }
         Button shareLogButton = findViewById(R.id.button_share_log);
         if (shareLogButton != null) {
             shareLogButton.setOnClickListener(v -> shareSessionLog());
@@ -310,6 +322,24 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
                 updateResolutionPreview();
             }
         });
+        editText.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                if (statusMonitorActive) {
+                    scheduleStatusCheck(800);
+                }
+            }
+        });
+
+        startStatusMonitor();
 
         // 无头模式，实际上要隐藏掉所有控件，否则会被显示出 ip 地址
         if (headlessMode) {
@@ -877,6 +907,7 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
 
     @SuppressLint("ClickableViewAccessibility")
     private void start_screen_copy_magic() {
+        stopStatusMonitor();
         setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR);
         setupMirrorContentView();
     }
@@ -937,6 +968,9 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
     protected void onPause() {
         super.onPause();
         Log.d("Scrcpy", "onPause: " + serviceBound);
+        if (first_time) {
+            stopStatusMonitor();
+        }
         if (serviceBound && scrcpy != null) {
             scrcpy.pause();
             resumeScrcpy = true;
@@ -946,6 +980,9 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
     @Override
     protected void onResume() {
         super.onResume();
+        if (first_time) {
+            startStatusMonitor();
+        }
         if (!first_time && !result_of_Rotation) {
             final View decorView = getWindow().getDecorView();
             decorView.setSystemUiVisibility(
@@ -1020,6 +1057,39 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
 
     }
 
+    private void confirmRebootRemoteDevice() {
+        getAttributes();
+        if (TextUtils.isEmpty(serverAdr)) {
+            Toast.makeText(context, "Server Address Empty", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        String[] serverInfo = Util.getServerHostAndPort(serverAdr);
+        String device = serverInfo[0] + ":" + serverInfo[1];
+        Dialog.displayDialog(this,
+                getString(R.string.reboot_title),
+                getString(R.string.reboot_ask, device),
+                () -> rebootRemoteDevice(device),
+                () -> {
+                });
+    }
+
+    private void rebootRemoteDevice(String device) {
+        Progress.showDialog(MainActivity.this, getString(R.string.reboot_wait));
+        ThreadUtils.workPost(() -> {
+            AdbHelper.adbCmd(App.mContext, "connect", device);
+            String result = AdbHelper.adbCmd(App.mContext, "-s", device, "reboot");
+            SessionLog.i("ADB reboot device=" + device + " result=" + result);
+            ThreadUtils.post(() -> {
+                Progress.closeDialog();
+                if (MainActivity.this.isFinishing()) {
+                    return;
+                }
+                Toast.makeText(context, getString(R.string.reboot_sent, device), Toast.LENGTH_SHORT).show();
+                startStatusMonitor();
+            });
+        });
+    }
+
     private void connectScrcpyServer(String serverAdr) {
         if (!TextUtils.isEmpty(serverAdr)) {
             saveHistory(serverAdr);  // 保存到历史记录
@@ -1062,14 +1132,87 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
                         }
                     });
                 } else {
-                    ThreadUtils.post(Progress::closeDialog);
-                    Toast.makeText(context, "Network OR ADB connection failed", Toast.LENGTH_SHORT).show();
-                    connectExitExt();
+                    ThreadUtils.post(() -> {
+                        Progress.closeDialog();
+                        Toast.makeText(context, "Network OR ADB connection failed", Toast.LENGTH_SHORT).show();
+                        startStatusMonitor();
+                        connectExitExt();
+                    });
                 }
             });
         } else {
             Toast.makeText(context, "Server Address Empty", Toast.LENGTH_SHORT).show();
+            startStatusMonitor();
             connectExitExt();
+        }
+    }
+
+    private void startStatusMonitor() {
+        if (headlessMode || isFinishing()) {
+            return;
+        }
+        View led = findViewById(R.id.status_led);
+        if (led == null) {
+            return;
+        }
+        statusMonitorActive = true;
+        scheduleStatusCheck(0);
+    }
+
+    private void stopStatusMonitor() {
+        statusMonitorActive = false;
+        statusCheckGeneration++;
+    }
+
+    private void scheduleStatusCheck(long delayMs) {
+        final int gen = ++statusCheckGeneration;
+        ThreadUtils.postDelayed(() -> {
+            if (!statusMonitorActive || gen != statusCheckGeneration) {
+                return;
+            }
+            EditText hostEdit = findViewById(R.id.editText_server_host);
+            final String hostText = hostEdit != null ? hostEdit.getText().toString().trim() : "";
+            ThreadUtils.execute(() -> {
+                boolean online = false;
+                if (!TextUtils.isEmpty(hostText)) {
+                    String[] serverInfo = Util.getServerHostAndPort(hostText);
+                    try {
+                        int port = Integer.parseInt(serverInfo[1]);
+                        online = AdbHelper.isDeviceOnline(App.mContext, serverInfo[0], port);
+                    } catch (NumberFormatException ignored) {
+                        online = false;
+                    }
+                }
+                final boolean onlineNow = online;
+                ThreadUtils.post(() -> {
+                    if (!statusMonitorActive || gen != statusCheckGeneration) {
+                        return;
+                    }
+                    applyStatusLed(onlineNow);
+                    scheduleStatusCheck(4000);
+                });
+            });
+        }, delayMs);
+    }
+
+    private void applyStatusLed(boolean online) {
+        View led = findViewById(R.id.status_led);
+        TextView label = findViewById(R.id.status_led_label);
+        if (led == null) {
+            return;
+        }
+        int color = getResources().getColor(online ? R.color.status_online : R.color.status_offline);
+        Drawable background = led.getBackground();
+        if (background instanceof GradientDrawable) {
+            ((GradientDrawable) background.mutate()).setColor(color);
+        } else if (background != null) {
+            background.mutate().setColorFilter(color, android.graphics.PorterDuff.Mode.SRC_ATOP);
+        } else {
+            led.setBackgroundColor(color);
+        }
+        if (label != null) {
+            label.setText(online ? R.string.status_online : R.string.status_offline);
+            label.setTextColor(color);
         }
     }
 

--- a/app/src/main/java/org/client/scrcpy/MainActivity.java
+++ b/app/src/main/java/org/client/scrcpy/MainActivity.java
@@ -24,6 +24,7 @@ import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.Display;
 import android.view.KeyEvent;
+import android.view.LayoutInflater;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
@@ -77,7 +78,6 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
     private SurfaceView surfaceView;
     private Surface surface;
     private SurfaceHolder.Callback surfaceCallback;
-    private boolean scrcpyServiceStarted = false;
     private Scrcpy scrcpy;
     private long timestamp = 0;
 
@@ -154,7 +154,6 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
             surfaceView.getHolder().removeCallback(surfaceCallback);
             surfaceView = null;
         }
-        scrcpyServiceStarted = false;
         surfaceCallback = null;
         if (surface != null) {
             surface = null;
@@ -183,12 +182,11 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
             screenHeight = savedInstanceState.getInt("screenHeight");
             screenWidth = savedInstanceState.getInt("screenWidth");
         }
-        // 读取屏幕是横屏、还是竖屏
-        landscape = getApplication().getResources().getConfiguration().orientation
-                != Configuration.ORIENTATION_PORTRAIT;
         if (first_time) {
             scrcpy_main();
         } else {
+            landscape = getResources().getConfiguration().orientation
+                    != Configuration.ORIENTATION_PORTRAIT;
             Log.e("Scrcpy: ", "from onCreate");
             start_screen_copy_magic();
         }
@@ -557,6 +555,119 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
         screenWidth = temp;
     }
 
+    private void syncLandscapeFromConfiguration() {
+        landscape = getResources().getConfiguration().orientation
+                != Configuration.ORIENTATION_PORTRAIT;
+    }
+
+    private void applyMirrorImmersiveMode() {
+        final View decorView = getWindow().getDecorView();
+        decorView.setSystemUiVisibility(
+                View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                        | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                        | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                        | View.SYSTEM_UI_FLAG_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+    }
+
+    private void refreshMirrorLayout() {
+        if (linearLayout == null || scrcpy == null) {
+            return;
+        }
+        linearLayout.setPadding(0, 0, 0, 0);
+        linearLayout.post(() -> {
+            if (serviceBound && scrcpy != null) {
+                set_display_nd_touch();
+                if (surfaceView != null) {
+                    Surface currentSurface = surfaceView.getHolder().getSurface();
+                    if (isSurfaceReady(currentSurface)) {
+                        surface = currentSurface;
+                        scrcpy.setParms(surface, screenWidth, screenHeight);
+                    }
+                }
+            }
+        });
+    }
+
+    private void setMirrorContentView() {
+        Configuration overrideConfig = new Configuration(getResources().getConfiguration());
+        overrideConfig.orientation = landscape
+                ? Configuration.ORIENTATION_LANDSCAPE
+                : Configuration.ORIENTATION_PORTRAIT;
+        View root = LayoutInflater.from(createConfigurationContext(overrideConfig))
+                .inflate(R.layout.surface, null);
+        setContentView(root);
+    }
+
+    private void setupNavBar() {
+        final LinearLayout nav_bar = findViewById(R.id.nav_button_bar);
+        if (nav_bar == null) {
+            return;
+        }
+        if (PreUtils.get(context, Constant.CONTROL_NAV, false) &&
+                !PreUtils.get(context, Constant.CONTROL_NO, false)) {
+            nav_bar.setVisibility(LinearLayout.VISIBLE);
+        } else {
+            nav_bar.setVisibility(LinearLayout.GONE);
+        }
+    }
+
+    private void bindMirrorSurfaceHolder() {
+        surfaceView = findViewById(R.id.decoder_surface);
+        if (surfaceView == null) {
+            return;
+        }
+        if (surfaceCallback != null) {
+            surfaceView.getHolder().removeCallback(surfaceCallback);
+        }
+        surfaceCallback = new SurfaceHolder.Callback() {
+            @Override
+            public void surfaceCreated(SurfaceHolder holder) {
+                surface = holder.getSurface();
+                if (!serviceBound) {
+                    start_Scrcpy_service();
+                } else if (scrcpy != null && isSurfaceReady(surface)) {
+                    scrcpy.setParms(surface, screenWidth, screenHeight);
+                    refreshMirrorLayout();
+                }
+            }
+
+            @Override
+            public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
+                surface = holder.getSurface();
+                if (serviceBound && scrcpy != null && isSurfaceReady(surface)) {
+                    scrcpy.setParms(surface, screenWidth, screenHeight);
+                    refreshMirrorLayout();
+                }
+            }
+
+            @Override
+            public void surfaceDestroyed(SurfaceHolder holder) {
+                surface = null;
+            }
+        };
+        surfaceView.getHolder().addCallback(surfaceCallback);
+    }
+
+    private void setupMirrorContentView() {
+        syncLandscapeFromConfiguration();
+        setMirrorContentView();
+        applyMirrorImmersiveMode();
+        bindMirrorSurfaceHolder();
+        setupNavBar();
+        linearLayout = findViewById(R.id.container1);
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        if (!first_time && serviceBound) {
+            result_of_Rotation = true;
+            setupMirrorContentView();
+        }
+    }
+
     private boolean isSurfaceReady(Surface displaySurface) {
         if (displaySurface == null) {
             return false;
@@ -569,50 +680,8 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
 
     @SuppressLint("ClickableViewAccessibility")
     private void start_screen_copy_magic() {
-        setContentView(R.layout.surface);
-        final View decorView = getWindow().getDecorView();
-        decorView.setSystemUiVisibility(
-                View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                        | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                        | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                        | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                        | View.SYSTEM_UI_FLAG_FULLSCREEN
-                        | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
-        surfaceView = findViewById(R.id.decoder_surface);
-        scrcpyServiceStarted = false;
-        surfaceCallback = new SurfaceHolder.Callback() {
-            @Override
-            public void surfaceCreated(SurfaceHolder holder) {
-                surface = holder.getSurface();
-                if (!scrcpyServiceStarted) {
-                    scrcpyServiceStarted = true;
-                    start_Scrcpy_service();
-                }
-            }
-
-            @Override
-            public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
-                surface = holder.getSurface();
-                if (serviceBound && scrcpy != null && isSurfaceReady(surface)) {
-                    scrcpy.setParms(surface, screenWidth, screenHeight);
-                }
-            }
-
-            @Override
-            public void surfaceDestroyed(SurfaceHolder holder) {
-                surface = null;
-            }
-        };
-        surfaceView.getHolder().addCallback(surfaceCallback);
-        final LinearLayout nav_bar = findViewById(R.id.nav_button_bar);
-        if (PreUtils.get(context, Constant.CONTROL_NAV, false) &&
-                !PreUtils.get(context, Constant.CONTROL_NO, false)) {
-            nav_bar.setVisibility(LinearLayout.VISIBLE);
-        } else {
-            nav_bar.setVisibility(LinearLayout.GONE);
-        }
-        linearLayout = findViewById(R.id.container1);
-        start_Scrcpy_service();
+        setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR);
+        setupMirrorContentView();
     }
 
     private void start_Scrcpy_service() {
@@ -624,24 +693,19 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
     @SuppressLint("SourceLockedOrientationActivity")
     @Override
     public void loadNewRotation() {
-        if (first_time) {
-            first_time = false;
-        }
-        try {
-            // 可能会导致重复解绑，所以捕获异常
-            unbindService(serviceConnection);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        serviceBound = false;
-        result_of_Rotation = true;
-        landscape = !landscape;
-        swapDimensions();
-        if (landscape) {
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
-        } else {
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
-        }
+        ThreadUtils.post(() -> {
+            if (first_time) {
+                first_time = false;
+            }
+            result_of_Rotation = true;
+            landscape = !landscape;
+            swapDimensions();
+            if (landscape) {
+                setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
+            } else {
+                setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
+            }
+        });
     }
 
     @Override
@@ -662,8 +726,8 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
     @Override
     protected void onStop() {
         super.onStop();
-        if (resumeScrcpy) {
-            // 返回到主页面，属于用户主动断开场景
+        if (resumeScrcpy && !isChangingConfigurations()) {
+            // 返回到主页面，属于用户主动断开场景（旋转屏幕时不断开）
             showMainView(true);
             first_time = true;
         }

--- a/app/src/main/java/org/client/scrcpy/MainActivity.java
+++ b/app/src/main/java/org/client/scrcpy/MainActivity.java
@@ -2,6 +2,7 @@ package org.client.scrcpy;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.ClipData;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
@@ -13,6 +14,7 @@ import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
@@ -47,6 +49,7 @@ import org.client.scrcpy.utils.AdbHelper;
 import org.client.scrcpy.utils.PreUtils;
 import org.client.scrcpy.utils.Progress;
 import org.client.scrcpy.utils.ResolutionHelper;
+import org.client.scrcpy.utils.SessionLog;
 import org.client.scrcpy.utils.ThreadUtils;
 import org.client.scrcpy.utils.Util;
 import org.json.JSONArray;
@@ -74,6 +77,9 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
     private SendCommands sendCommands;
     private int videoBitrate;
     private int delayControl;
+    private String videoCodec = Options.CODEC_H264;
+    private String videoEncoder = "";
+    private int videoFrameRate = 60;
     private Context context;
     private String serverAdr = null;
     private SurfaceView surfaceView;
@@ -99,7 +105,8 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
                 }
                 scrcpy.start(surface, Scrcpy.LOCAL_IP + ":" + Scrcpy.LOCAL_FORWART_PORT,
                         screenHeight, screenWidth, delayControl,
-                        PreUtils.get(MainActivity.this, Constant.AUDIO_FORWARD, true));
+                        PreUtils.get(MainActivity.this, Constant.AUDIO_FORWARD, true),
+                        videoCodec);
                 ThreadUtils.workPost(() -> {
                     boolean success = AdbHelper.executeWithTimeout(() -> {
                         while (!scrcpy.check_socket_connection()) {
@@ -248,6 +255,11 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
         landscape = false;  // 将模式重新置为 竖屏，模式不正确将导致连接黑屏
         setContentView(R.layout.activity_main);
 
+        TextView titleView = findViewById(R.id.app_title);
+        if (titleView != null) {
+            titleView.setText(getString(R.string.app_title) + "  " + BuildConfig.VERSION_NAME + "  r" + BuildConfig.VERSION_CODE);
+        }
+
         // find view by id
         ScrollView scrollView = findViewById(R.id.main_scroll_view);
         Button startButton = findViewById(R.id.button_start);
@@ -258,8 +270,18 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
 
         startButton.setOnClickListener(v -> {
             getAttributes();
+            SessionLog.i("Start clicked host=" + serverAdr
+                    + " max=" + Math.max(screenHeight, screenWidth)
+                    + " bitrate=" + videoBitrate
+                    + " codec=" + videoCodec
+                    + " encoder=" + videoEncoder
+                    + " fps=" + videoFrameRate);
             connectScrcpyServer(serverAdr);
         });
+        Button shareLogButton = findViewById(R.id.button_share_log);
+        if (shareLogButton != null) {
+            shareLogButton.setOnClickListener(v -> shareSessionLog());
+        }
         btnMoreSettings.setOnClickListener(v -> {
             AutoTransition autoTransition = new AutoTransition();
             TransitionManager.beginDelayedTransition(scrollView, autoTransition);
@@ -320,6 +342,30 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
         listPopupWindow.show();
     }
 
+    private void shareSessionLog() {
+        java.io.File logFile = SessionLog.getFile();
+        if (logFile == null || !logFile.exists() || logFile.length() == 0) {
+            Toast.makeText(this, R.string.share_log_empty, Toast.LENGTH_SHORT).show();
+            return;
+        }
+        String subject = getString(R.string.share_log_subject, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE);
+        Uri uri = Uri.parse("content://" + getPackageName() + ".log/session.log");
+        Intent send = new Intent(Intent.ACTION_SEND);
+        send.setType("text/plain");
+        send.putExtra(Intent.EXTRA_SUBJECT, subject);
+        // WhatsApp: solo riassunto ~400 caratteri. Il log intero è l'allegato.
+        send.putExtra(Intent.EXTRA_TEXT, SessionLog.readPreview());
+        send.putExtra(Intent.EXTRA_STREAM, uri);
+        send.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        send.setClipData(ClipData.newRawUri("scrcpy-session.log", uri));
+        try {
+            startActivity(Intent.createChooser(send, getString(R.string.action_share_log)));
+        } catch (Exception e) {
+            SessionLog.e("Share log failed", e);
+            Toast.makeText(this, e.getMessage(), Toast.LENGTH_SHORT).show();
+        }
+    }
+
 
 //    private void showDisplayWindow() {
 //        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
@@ -359,8 +405,14 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
         audioForwardSwitch.setChecked(PreUtils.get(context, Constant.AUDIO_FORWARD, true));
 
         setSpinner(R.array.options_bitrate_keys, R.id.spinner_video_bitrate, Constant.PREFERENCE_SPINNER_BITRATE);
+        setSpinner(R.array.options_codec_keys, R.id.spinner_video_codec, Constant.PREFERENCE_SPINNER_CODEC);
+        setSpinner(R.array.options_fps_keys, R.id.spinner_video_fps, Constant.PREFERENCE_SPINNER_FPS);
         setSpinner(R.array.options_delay_keys, R.id.delay_control_spinner, Constant.PREFERENCE_SPINNER_DELAY);
         setupResolutionSpinner();
+
+        EditText encoderEdit = findViewById(R.id.editText_video_encoder);
+        encoderEdit.setText(PreUtils.get(context, Constant.PREFERENCE_VIDEO_ENCODER, ""));
+
         if (aSwitch0.isChecked()) {
             aSwitch1.setClickable(false);
             aSwitch1.setTextColor(Color.GRAY);
@@ -402,35 +454,27 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
                 this_dev_height = this_dev_height - 96;
             }
         }
-        int[] rem_res = scrcpy.get_remote_device_resolution();
-        int remote_device_height = rem_res[1];
-        int remote_device_width = rem_res[0];
-        float remote_device_aspect_ratio = (float) remote_device_height / remote_device_width;
-
-        if (!landscape) {                                                            //Portrait
-            float this_device_aspect_ratio = this_dev_height / this_dev_width;
-//            Log.d("fuck", "set_display_nd_touch: "+this_device_aspect_ratio);
-            if (remote_device_aspect_ratio > this_device_aspect_ratio) {
-                //TODO
-                float wantWidth = this_dev_height / remote_device_aspect_ratio;
-                int padding = (int) (this_dev_width - wantWidth) / 2;
-                linearLayout.setPadding(padding, 0, padding, 0);
-            } else if (remote_device_aspect_ratio < this_device_aspect_ratio) {
-                linearLayout.setPadding(0, (int) (((this_device_aspect_ratio - remote_device_aspect_ratio) * this_dev_width)), 0, 0);
+        int[] remote = scrcpy.getOrientedRemoteSize(landscape);
+        int remoteW = remote[0];
+        int remoteH = remote[1];
+        if (remoteW <= 0 || remoteH <= 0 || this_dev_width <= 0 || this_dev_height <= 0) {
+            if (!PreUtils.get(context, Constant.CONTROL_NO, false)) {
+                surfaceView.setOnTouchListener((view, event) ->
+                        scrcpy.touchevent(event, landscape, surfaceView.getWidth(), surfaceView.getHeight()));
             }
-
-        } else {                                                                        //Landscape
-            float this_device_aspect_ratio = this_dev_width / this_dev_height;
-//            Log.d("fuck", "set_display_nd_touch_land: "+this_device_aspect_ratio);
-            if (remote_device_aspect_ratio > this_device_aspect_ratio) {
-                float wantHeight = this_dev_width / remote_device_aspect_ratio;
-                int padding = (int) (this_dev_height - wantHeight) / 2;
-                linearLayout.setPadding(0, padding, 0, padding);
-            } else if (remote_device_aspect_ratio < this_device_aspect_ratio) {
-                linearLayout.setPadding(((int) (((this_device_aspect_ratio - remote_device_aspect_ratio) * this_dev_height)) / 2), 0, ((int) (((this_device_aspect_ratio - remote_device_aspect_ratio) * this_dev_height)) / 2), 0);
-            }
-
+            return;
         }
+
+        float scale = Math.min(this_dev_width / remoteW, this_dev_height / remoteH);
+        int contentW = Math.round(remoteW * scale);
+        int contentH = Math.round(remoteH * scale);
+        int padH = Math.max(0, ((int) this_dev_width - contentW) / 2);
+        int padV = Math.max(0, ((int) this_dev_height - contentH) / 2);
+        linearLayout.setPadding(padH, padV, padH, padV);
+        Log.i("Scrcpy", "Fit remote " + remoteW + "x" + remoteH
+                + " into " + (int) this_dev_width + "x" + (int) this_dev_height
+                + " content=" + contentW + "x" + contentH
+                + " pad=" + padH + "," + padV);
         if (!PreUtils.get(context, Constant.CONTROL_NO, false)) {
             // Log.i("Screen", "setOnTouchListener: " + surfaceView.getWidth() + "x" + surfaceView.getHeight());
             surfaceView.setOnTouchListener((view, event) -> scrcpy.touchevent(event, landscape, surfaceView.getWidth(), surfaceView.getHeight()));
@@ -590,7 +634,10 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
         }
         final Spinner videoResolutionSpinner = findViewById(R.id.spinner_video_resolution);
         final Spinner videoBitrateSpinner = findViewById(R.id.spinner_video_bitrate);
+        final Spinner videoCodecSpinner = findViewById(R.id.spinner_video_codec);
+        final Spinner videoFpsSpinner = findViewById(R.id.spinner_video_fps);
         final Spinner delayControlSpinner = findViewById(R.id.delay_control_spinner);
+        final EditText encoderEdit = findViewById(R.id.editText_video_encoder);
 
         Switch a_Switch0 = findViewById(R.id.switch0);
         Switch a_Switch1 = findViewById(R.id.switch1);
@@ -599,15 +646,28 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
         PreUtils.put(context, Constant.CONTROL_NAV, a_Switch1.isChecked());
         PreUtils.put(context, Constant.AUDIO_FORWARD, audioEnableSwitch.isChecked());
 
-        final String[] videoResolutions = getResources().getStringArray(R.array.options_resolution_values)[videoResolutionSpinner.getSelectedItemPosition()].split("x");
-        autoResolutionEnabled = videoResolutionSpinner.getSelectedItemPosition() == Constant.RESOLUTION_AUTO_INDEX;
+        String resolutionValue = getResources().getStringArray(R.array.options_resolution_values)[videoResolutionSpinner.getSelectedItemPosition()];
+        autoResolutionEnabled = videoResolutionSpinner.getSelectedItemPosition() == Constant.RESOLUTION_AUTO_INDEX
+                || "0".equals(resolutionValue) || "auto".equalsIgnoreCase(resolutionValue);
         resolutionLimitSource = null;
-        if (!autoResolutionEnabled) {
+        if (autoResolutionEnabled) {
+            screenHeight = 0;
+            screenWidth = 0;
+        } else if (resolutionValue.contains("x")) {
+            final String[] videoResolutions = resolutionValue.split("x");
             screenHeight = Integer.parseInt(videoResolutions[0]);
             screenWidth = Integer.parseInt(videoResolutions[1]);
+        } else {
+            int maxSize = Integer.parseInt(resolutionValue);
+            screenHeight = maxSize;
+            screenWidth = maxSize;
         }
         videoBitrate = getResources().getIntArray(R.array.options_bitrate_values)[videoBitrateSpinner.getSelectedItemPosition()];
+        videoCodec = getResources().getStringArray(R.array.options_codec_values)[videoCodecSpinner.getSelectedItemPosition()];
+        videoFrameRate = getResources().getIntArray(R.array.options_fps_values)[videoFpsSpinner.getSelectedItemPosition()];
         delayControl = getResources().getIntArray(R.array.options_delay_values)[delayControlSpinner.getSelectedItemPosition()];
+        videoEncoder = encoderEdit.getText() == null ? "" : encoderEdit.getText().toString().trim();
+        PreUtils.put(context, Constant.PREFERENCE_VIDEO_ENCODER, videoEncoder);
     }
 
     private String[] getHistoryList() {
@@ -965,12 +1025,19 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
                     final String resolutionMessage = formatResolutionMessage(autoResolution, false);
                     ThreadUtils.post(() -> updateResolutionInfoText(resolutionMessage));
                 }
+                Options options = new Options();
+                options.setIp(Scrcpy.LOCAL_IP);
+                options.setMaxSize(Math.max(screenHeight, screenWidth));
+                options.setBitRate(videoBitrate);
+                options.setTunnelForward(true);
+                options.setEnableAudioForward(PreUtils.get(context, Constant.AUDIO_FORWARD, true));
+                options.setVideoCodec(videoCodec);
+                options.setVideoEncoder(videoEncoder);
+                options.setFrameRate(videoFrameRate);
                 SendCommands.CmdStatus sendStatus = sendCommands.SendAdbCommands(context, serverHost,
                         serverPort,
                         localForwardPort,
-                        Scrcpy.LOCAL_IP,
-                        videoBitrate, Math.max(screenHeight, screenWidth),
-                        PreUtils.get(context, Constant.AUDIO_FORWARD, true));
+                        options);
                 if (sendStatus == SendCommands.CmdStatus.SUCCESS) {
                     ThreadUtils.post(() -> {
                         if (!MainActivity.this.isFinishing()) {

--- a/app/src/main/java/org/client/scrcpy/MainActivity.java
+++ b/app/src/main/java/org/client/scrcpy/MainActivity.java
@@ -518,6 +518,7 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
             final View backButton = findViewById(R.id.back_button);
             final View homeButton = findViewById(R.id.home_button);
             final View appswitchButton = findViewById(R.id.appswitch_button);
+            final View powerButton = findViewById(R.id.power_button);
 
             if (backButton != null) {
                 backButton.setOnClickListener(v -> scrcpy.sendKeyevent(KeyEvent.KEYCODE_BACK));
@@ -527,6 +528,9 @@ public class MainActivity extends Activity implements Scrcpy.ServiceCallbacks, S
             }
             if (appswitchButton != null) {
                 appswitchButton.setOnClickListener(v -> scrcpy.sendKeyevent(KeyEvent.KEYCODE_APP_SWITCH));
+            }
+            if (powerButton != null) {
+                powerButton.setOnClickListener(v -> scrcpy.sendKeyevent(KeyEvent.KEYCODE_POWER));
             }
         }
     }

--- a/app/src/main/java/org/client/scrcpy/Options.java
+++ b/app/src/main/java/org/client/scrcpy/Options.java
@@ -1,13 +1,21 @@
 package org.client.scrcpy;
 
+import android.text.TextUtils;
+
 public class Options {
+
+    public static final String CODEC_H264 = "h264";
+    public static final String CODEC_H265 = "h265";
+    public static final String DEFAULT_ENCODER = "-";
 
     private String ip;
     private int maxSize;
     private int bitRate;
     private boolean tunnelForward;
-
     private boolean enableAudioForward = true;
+    private String videoCodec = CODEC_H264;
+    private String videoEncoder = DEFAULT_ENCODER;
+    private int frameRate = 60;
 
     public String getIp() {
         return ip;
@@ -49,11 +57,59 @@ public class Options {
         this.tunnelForward = tunnelForward;
     }
 
+    public String getVideoCodec() {
+        return videoCodec;
+    }
 
-    /***
-     * 从 args 中还原参数
-     * @param args
-     * @return
+    public void setVideoCodec(String videoCodec) {
+        this.videoCodec = normalizeCodec(videoCodec);
+    }
+
+    public String getVideoEncoder() {
+        return videoEncoder;
+    }
+
+    public void setVideoEncoder(String videoEncoder) {
+        if (TextUtils.isEmpty(videoEncoder) || DEFAULT_ENCODER.equals(videoEncoder)) {
+            this.videoEncoder = DEFAULT_ENCODER;
+        } else {
+            this.videoEncoder = videoEncoder.trim();
+        }
+    }
+
+    public int getFrameRate() {
+        return frameRate;
+    }
+
+    public void setFrameRate(int frameRate) {
+        this.frameRate = frameRate > 0 ? frameRate : 60;
+    }
+
+    public String getVideoMimeType() {
+        return mimeForCodec(videoCodec);
+    }
+
+    public boolean hasCustomEncoder() {
+        return !TextUtils.isEmpty(videoEncoder) && !DEFAULT_ENCODER.equals(videoEncoder);
+    }
+
+    public static String normalizeCodec(String codec) {
+        if (codec == null) {
+            return CODEC_H264;
+        }
+        String value = codec.trim().toLowerCase();
+        if ("h265".equals(value) || "hevc".equals(value)) {
+            return CODEC_H265;
+        }
+        return CODEC_H264;
+    }
+
+    public static String mimeForCodec(String codec) {
+        return CODEC_H265.equals(normalizeCodec(codec)) ? "video/hevc" : "video/avc";
+    }
+
+    /**
+     * Restore options from server args. Extra args are optional for backward compatibility.
      */
     public static Options createOptions(String[] args) {
         Options options = new Options();
@@ -62,12 +118,20 @@ public class Options {
         options.bitRate = Integer.parseInt(args[2]);
         options.tunnelForward = Boolean.parseBoolean(args[3]);
         options.enableAudioForward = Boolean.parseBoolean(args[4]);
+        if (args.length > 5) {
+            options.setVideoCodec(args[5]);
+        }
+        if (args.length > 6) {
+            options.setVideoEncoder(args[6]);
+        }
+        if (args.length > 7) {
+            options.setFrameRate(Integer.parseInt(args[7]));
+        }
         return options;
     }
 
     /**
-     * 将参数转为 args 传递给 scrcpy server
-     * @return
+     * Serialize options as args for the scrcpy server process.
      */
     public String[] optionsToArgs() {
         return new String[]{
@@ -75,7 +139,10 @@ public class Options {
                 Long.toString(maxSize),
                 Long.toString(bitRate),
                 String.valueOf(tunnelForward),
-                String.valueOf(enableAudioForward)
+                String.valueOf(enableAudioForward),
+                videoCodec,
+                hasCustomEncoder() ? videoEncoder : DEFAULT_ENCODER,
+                Integer.toString(frameRate)
         };
     }
 }

--- a/app/src/main/java/org/client/scrcpy/Scrcpy.java
+++ b/app/src/main/java/org/client/scrcpy/Scrcpy.java
@@ -55,7 +55,10 @@ public class Scrcpy extends Service {
     private final AtomicBoolean LetServceRunning = new AtomicBoolean(true);
     private ServiceCallbacks serviceCallbacks;
     private final int[] remote_dev_resolution = new int[2];
+    private final int[] remote_video_resolution = new int[2];
     private boolean socket_status = false;
+
+    private String videoMimeType = "video/avc";
 
     private DataInputStream socketInputStream = null;
     private DataOutputStream socketOutputStream = null;
@@ -97,11 +100,10 @@ public class Scrcpy extends Service {
     }
 
     public void start(Surface surface, String serverAdr, int screenHeight, int screenWidth, int delay, boolean enableAudio) {
-//        this.videoDecoder = new VideoDecoder();
-//        videoDecoder.start();
-//        this.audioDecoder = new AudioDecoder();
-//        audioDecoder.start();
+        start(surface, serverAdr, screenHeight, screenWidth, delay, enableAudio, Options.CODEC_H264);
+    }
 
+    public void start(Surface surface, String serverAdr, int screenHeight, int screenWidth, int delay, boolean enableAudio, String videoCodec) {
         String[] serverInfo = Util.getServerHostAndPort(serverAdr);
         this.serverHost = serverInfo[0];
         this.serverPort = Integer.parseInt(serverInfo[1]);
@@ -109,6 +111,7 @@ public class Scrcpy extends Service {
         this.screenHeight = screenHeight;
         this.screenWidth = screenWidth;
         this.surface = surface;
+        this.videoMimeType = Options.CODEC_H265.equalsIgnoreCase(videoCodec) ? "video/hevc" : "video/avc";
         Thread thread = new Thread(new Runnable() {
             @Override
             public void run() {
@@ -157,51 +160,43 @@ public class Scrcpy extends Service {
 
 
     public boolean touchevent(MotionEvent touch_event, boolean landscape, int displayW, int displayH) {
-        float remoteW;
-        float remoteH;
-        float realH;
-        float realW;
-
-        if (landscape) {  // 横屏的话，宽高相反
-            remoteW = Math.max(remote_dev_resolution[0], remote_dev_resolution[1]);
-            remoteH = Math.min(remote_dev_resolution[0], remote_dev_resolution[1]);
-
-            realW = Math.min(remoteW, screenWidth);
-            realH = realW * remoteH / remoteW;
-        } else {
-            remoteW = Math.min(remote_dev_resolution[0], remote_dev_resolution[1]);
-            remoteH = Math.max(remote_dev_resolution[0], remote_dev_resolution[1]);
-            realH = Math.min(remoteH, screenHeight);
-            realW = realH * remoteW / remoteH;
+        if (displayW <= 0 || displayH <= 0) {
+            return true;
         }
 
+        int[] remote = getOrientedRemoteSize(landscape);
+        float remoteW = remote[0];
+        float remoteH = remote[1];
+        if (remoteW <= 0 || remoteH <= 0) {
+            return true;
+        }
+
+        int actionMasked = touch_event.getActionMasked();
         int actionIndex = touch_event.getActionIndex();
         int pointerId = touch_event.getPointerId(actionIndex);
-        int pointCount = touch_event.getPointerCount();
-        // Log.e("Scrcpy", "pointer id: " + pointerId + " , action: " + touch_event.getAction() + " ,point count: " + pointCount + " x: " + touch_event.getX() + " y: " + touch_event.getY());
 
-        switch (touch_event.getAction()) {
-            case MotionEvent.ACTION_MOVE: // 所有手指移动
-                // 遍历所有触摸点，使用 pointerId 和 pointerIndex 来获取所有触摸点的信息
-                for (int i = 0; i < touch_event.getPointerCount(); i++) {
-                    int currentPointerId = touch_event.getPointerId(i);
-                    int x = (int) touch_event.getX(i);
-                    int y = (int) touch_event.getY(i);
-                    // 处理每一个触摸点的x, y坐标
-                    // Log.e("Scrcpy", "触摸移动，index : " + i + " ,x : " + x + " , y: " + y + " ,currentPointerId: " + currentPointerId);
-                    sendTouchEvent(touch_event.getAction(), touch_event.getButtonState(), (int) (x * realW / displayW), (int) (y * realH / displayH), currentPointerId);
-                }
-                break;
-            case MotionEvent.ACTION_POINTER_UP: // 中间手指抬起
-            case MotionEvent.ACTION_UP: // 最后一个手指抬起
-            case MotionEvent.ACTION_DOWN: // 第一个手指按下
-            case MotionEvent.ACTION_POINTER_DOWN: // 中间的手指按下
-            default:
-                sendTouchEvent(touch_event.getAction(), touch_event.getButtonState(), (int) (touch_event.getX() * realW / displayW), (int) (touch_event.getY() * realH / displayH), pointerId);
-                break;
-
+        if (actionMasked == MotionEvent.ACTION_MOVE) {
+            for (int i = 0; i < touch_event.getPointerCount(); i++) {
+                int currentPointerId = touch_event.getPointerId(i);
+                int x = mapToRemote((int) touch_event.getX(i), displayW, remoteW);
+                int y = mapToRemote((int) touch_event.getY(i), displayH, remoteH);
+                sendTouchEvent(touch_event.getAction(), touch_event.getButtonState(), x, y, currentPointerId);
+            }
+        } else {
+            int x = mapToRemote((int) touch_event.getX(), displayW, remoteW);
+            int y = mapToRemote((int) touch_event.getY(), displayH, remoteH);
+            if (actionMasked == MotionEvent.ACTION_DOWN) {
+                Log.i("Scrcpy", "touch DOWN " + x + "," + y + " surface=" + displayW + "x" + displayH
+                        + " remote=" + (int) remoteW + "x" + (int) remoteH
+                        + " video=" + remote_video_resolution[0] + "x" + remote_video_resolution[1]);
+            }
+            sendTouchEvent(touch_event.getAction(), touch_event.getButtonState(), x, y, pointerId);
         }
         return true;
+    }
+
+    private static int mapToRemote(int value, int surfaceSize, float remoteSize) {
+        return (int) (value * remoteSize / surfaceSize);
     }
 
     private void sendTouchEvent(int action, int buttonState, int x, int y, int pointerId) {
@@ -224,6 +219,15 @@ public class Scrcpy extends Service {
 
     public int[] get_remote_device_resolution() {
         return remote_dev_resolution;
+    }
+
+    public int[] getOrientedRemoteSize(boolean landscape) {
+        int a = remote_dev_resolution[0];
+        int b = remote_dev_resolution[1];
+        if (landscape) {
+            return new int[]{Math.max(a, b), Math.min(a, b)};
+        }
+        return new int[]{Math.min(a, b), Math.max(a, b)};
     }
 
     public boolean check_socket_connection() {
@@ -274,15 +278,17 @@ public class Scrcpy extends Service {
 
                 Log.e("Scrcpy", "Connecting to " + LOCAL_IP + " success");
 
-                // 能够正常进行连接，说明可能建立了 tcp 连接，需要等待数据
-                // 一次等待时间为 2s ，最多等待五次，也就是 10秒
-                if (firstConnect) {  // 此处有 while 循环，不能一直设置为10
+                // Il server accetta una sola connessione: non chiudere il primo socket troppo presto.
+                // ADB forward può risultare "connected" prima che app_process sia in listen.
+                int waitResolutionCount;
+                if (firstConnect) {
                     firstConnect = false;
-                    // waitResolutionCount 为 10，等待100ms 也就是共计一秒钟，设置attempts 为 5，也就是 5秒后则退出
-                    attempts = 5;
+                    attempts = 8;
+                    waitResolutionCount = 50; // 5s sul primo tentativo
+                } else {
+                    waitResolutionCount = 20; // 2s sui retry
                 }
                 dataInputStream = new DataInputStream(socket.getInputStream());
-                int waitResolutionCount = 10;
                 while (dataInputStream.available() <= 0 && waitResolutionCount > 0) {
                     waitResolutionCount--;
                     try {
@@ -298,13 +304,20 @@ public class Scrcpy extends Service {
                 dataOutputStream = new DataOutputStream(socket.getOutputStream());
                 attempts = 0;
                 byte[] buf = new byte[16];
-                dataInputStream.read(buf, 0, 16);
-                for (int i = 0; i < remote_dev_resolution.length; i++) {
-                    remote_dev_resolution[i] = (((int) (buf[i * 4]) << 24) & 0xFF000000) |
+                dataInputStream.readFully(buf, 0, 16);
+                int[] handshake = new int[4];
+                for (int i = 0; i < handshake.length; i++) {
+                    handshake[i] = (((int) (buf[i * 4]) << 24) & 0xFF000000) |
                             (((int) (buf[i * 4 + 1]) << 16) & 0xFF0000) |
                             (((int) (buf[i * 4 + 2]) << 8) & 0xFF00) |
                             ((int) (buf[i * 4 + 3]) & 0xFF);
                 }
+                remote_dev_resolution[0] = handshake[0];
+                remote_dev_resolution[1] = handshake[1];
+                remote_video_resolution[0] = handshake[2];
+                remote_video_resolution[1] = handshake[3];
+                Log.i("Scrcpy", "Handshake device=" + handshake[0] + "x" + handshake[1]
+                        + " video=" + handshake[2] + "x" + handshake[3]);
                 if (remote_dev_resolution[0] > remote_dev_resolution[1]) {
                     first_time = false;
                     int i = remote_dev_resolution[0];
@@ -397,8 +410,9 @@ public class Scrcpy extends Service {
         while (LetServceRunning.get()) {
             boolean waitEvent = true;
             try {
-                byte[] sendevent = event.poll();
-                if (sendevent != null) {
+                byte[] sendevent;
+                int drained = 0;
+                while ((sendevent = event.poll()) != null) {
                     waitEvent = false;
                     try {
                         byte[] data = ControlPacket.toArray(MediaPacket.Type.CONTROL, sendevent);
@@ -409,9 +423,15 @@ public class Scrcpy extends Service {
                             serviceCallbacks.errorDisconnect();
                         }
                         LetServceRunning.set(false);
-                    } finally {
-                        // event = null;
+                        break;
                     }
+                    drained++;
+                    if (drained >= 64) {
+                        break;
+                    }
+                }
+                if (drained > 0) {
+                    dataOutputStream.flush();
                 }
 
                 if (dataInputStream.available() > 0) {
@@ -435,7 +455,7 @@ public class Scrcpy extends Service {
                                 int dataLength = packet.length - videoPacket.headLength();
                                 byte[] data = new byte[dataLength];
                                 System.arraycopy(packet, videoPacket.headLength(), data, 0, dataLength);
-                                streamSettings = VideoPacket.getStreamSettings(data);
+                                streamSettings = VideoPacket.getStreamSettings(data, "video/hevc".equals(videoMimeType));
                                 if (!first_time) {
                                     if (serviceCallbacks != null) {
                                         serviceCallbacks.loadNewRotation();
@@ -452,33 +472,48 @@ public class Scrcpy extends Service {
                                 }
                             }
                             updateAvailable.set(false);
-                            if (streamSettings != null && isSurfaceReady(surface)) {
-                                videoDecoder.configure(surface, screenWidth, screenHeight, streamSettings.sps, streamSettings.pps);
-                            } else if (streamSettings != null) {
-                                Log.e("Scrcpy", "Skipping video configure: surface not ready");
+                            if (streamSettings != null) {
+                                int decodeW = remote_video_resolution[0] > 0
+                                        ? remote_video_resolution[0]
+                                        : (remote_dev_resolution[0] > 0 ? remote_dev_resolution[0] : screenWidth);
+                                int decodeH = remote_video_resolution[1] > 0
+                                        ? remote_video_resolution[1]
+                                        : (remote_dev_resolution[1] > 0 ? remote_dev_resolution[1] : screenHeight);
+                                if (!isSurfaceReady(surface)) {
+                                    Log.e("Scrcpy", "Skipping video configure: surface not ready");
+                                } else {
+                                    Log.i("Scrcpy", "Decoder configure " + decodeW + "x" + decodeH);
+                                    videoDecoder.configure(surface, decodeW, decodeH, streamSettings.sps, streamSettings.pps, videoMimeType);
+                                }
                             }
                         } else if (videoPacket.flag == VideoPacket.Flag.END) {
                             // need close stream
                             Log.e("Scrcpy", "END ... ");
                         } else {
                             // Log.e("Scrcpy", "videoPacket presentationTimeStamp ... " + videoPacket.presentationTimeStamp);
-                            // 帧在 100 ms 以内
                             if (lastVideoOffset == 0) {
                                 lastVideoOffset = System.currentTimeMillis() - (videoPacket.presentationTimeStamp / 1000);
                             }
+                            long latencyMs = System.currentTimeMillis() - (lastVideoOffset + (videoPacket.presentationTimeStamp / 1000));
+                            // delay troppo aggressivo = schermo nero permanente: decodifica sempre i keyframe
+                            // e i frame entro la soglia; se in ritardo chiedi un nuovo keyframe ma non bloccare per sempre
                             if (videoPacket.flag == VideoPacket.Flag.KEY_FRAME) {
-                                if (System.currentTimeMillis() - (lastVideoOffset + (videoPacket.presentationTimeStamp / 1000)) < delay) {
-                                    waitKeyFrame = false;
+                                waitKeyFrame = false;
+                                if (latencyMs > delay * 3L) {
+                                    // stream molto in ritardo: riallinea l'offset e continua
+                                    lastVideoOffset = System.currentTimeMillis() - (videoPacket.presentationTimeStamp / 1000);
+                                }
+                                videoDecoder.decodeSample(packet, videoPacket.headLength(), packet.length - videoPacket.headLength(),
+                                        0, videoPacket.flag.getFlag());
+                            } else {
+                                if (waitKeyFrame) {
+                                    requestNewKeyFrame();
+                                } else if (latencyMs <= Math.max(delay, 200)) {
                                     videoDecoder.decodeSample(packet, videoPacket.headLength(), packet.length - videoPacket.headLength(),
                                             0, videoPacket.flag.getFlag());
                                 } else {
                                     waitKeyFrame = true;
                                     requestNewKeyFrame();
-                                }
-                            } else {
-                                if (!waitKeyFrame) {
-                                    videoDecoder.decodeSample(packet, videoPacket.headLength(), packet.length - videoPacket.headLength(),
-                                            0, videoPacket.flag.getFlag());
                                 }
                             }
                         }

--- a/app/src/main/java/org/client/scrcpy/Scrcpy.java
+++ b/app/src/main/java/org/client/scrcpy/Scrcpy.java
@@ -72,16 +72,28 @@ public class Scrcpy extends Service {
     public void setParms(Surface NewSurface, int NewWidth, int NewHeight) {
         this.screenWidth = NewWidth;
         this.screenHeight = NewHeight;
-        this.surface = NewSurface;
+        if (NewSurface != null) {
+            this.surface = NewSurface;
+        }
 
-        if(videoDecoder != null){
+        if (videoDecoder != null) {
             videoDecoder.start();
         }
-        if(audioDecoder != null){
+        if (audioDecoder != null) {
             audioDecoder.start();
         }
 
         updateAvailable.set(true);
+    }
+
+    private boolean isSurfaceReady(Surface displaySurface) {
+        if (displaySurface == null) {
+            return false;
+        }
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            return displaySurface.isValid();
+        }
+        return true;
     }
 
     public void start(Surface surface, String serverAdr, int screenHeight, int screenWidth, int delay, boolean enableAudio) {
@@ -440,8 +452,10 @@ public class Scrcpy extends Service {
                                 }
                             }
                             updateAvailable.set(false);
-                            if (streamSettings != null) {
+                            if (streamSettings != null && isSurfaceReady(surface)) {
                                 videoDecoder.configure(surface, screenWidth, screenHeight, streamSettings.sps, streamSettings.pps);
+                            } else if (streamSettings != null) {
+                                Log.e("Scrcpy", "Skipping video configure: surface not ready");
                             }
                         } else if (videoPacket.flag == VideoPacket.Flag.END) {
                             // need close stream

--- a/app/src/main/java/org/client/scrcpy/Scrcpy.java
+++ b/app/src/main/java/org/client/scrcpy/Scrcpy.java
@@ -99,6 +99,25 @@ public class Scrcpy extends Service {
         return true;
     }
 
+    private boolean tryConfigureVideoDecoder(VideoPacket.StreamSettings streamSettings) {
+        if (streamSettings == null || videoDecoder == null) {
+            return false;
+        }
+        int decodeW = remote_video_resolution[0] > 0
+                ? remote_video_resolution[0]
+                : (remote_dev_resolution[0] > 0 ? remote_dev_resolution[0] : screenWidth);
+        int decodeH = remote_video_resolution[1] > 0
+                ? remote_video_resolution[1]
+                : (remote_dev_resolution[1] > 0 ? remote_dev_resolution[1] : screenHeight);
+        if (!isSurfaceReady(surface)) {
+            Log.e("Scrcpy", "Skipping video configure: surface not ready");
+            return false;
+        }
+        Log.i("Scrcpy", "Decoder configure " + decodeW + "x" + decodeH);
+        videoDecoder.configure(surface, decodeW, decodeH, streamSettings.sps, streamSettings.pps, videoMimeType);
+        return true;
+    }
+
     public void start(Surface surface, String serverAdr, int screenHeight, int screenWidth, int delay, boolean enableAudio) {
         start(surface, serverAdr, screenHeight, screenWidth, delay, enableAudio, Options.CODEC_H264);
     }
@@ -178,25 +197,54 @@ public class Scrcpy extends Service {
         if (actionMasked == MotionEvent.ACTION_MOVE) {
             for (int i = 0; i < touch_event.getPointerCount(); i++) {
                 int currentPointerId = touch_event.getPointerId(i);
-                int x = mapToRemote((int) touch_event.getX(i), displayW, remoteW);
-                int y = mapToRemote((int) touch_event.getY(i), displayH, remoteH);
-                sendTouchEvent(touch_event.getAction(), touch_event.getButtonState(), x, y, currentPointerId);
+                int[] mapped = mapTouchToRemote(touch_event.getX(i), touch_event.getY(i),
+                        displayW, displayH, remoteW, remoteH);
+                sendTouchEvent(touch_event.getAction(), touch_event.getButtonState(),
+                        mapped[0], mapped[1], currentPointerId);
             }
         } else {
-            int x = mapToRemote((int) touch_event.getX(), displayW, remoteW);
-            int y = mapToRemote((int) touch_event.getY(), displayH, remoteH);
+            int[] mapped = mapTouchToRemote(touch_event.getX(), touch_event.getY(),
+                    displayW, displayH, remoteW, remoteH);
             if (actionMasked == MotionEvent.ACTION_DOWN) {
-                Log.i("Scrcpy", "touch DOWN " + x + "," + y + " surface=" + displayW + "x" + displayH
+                Log.i("Scrcpy", "touch DOWN " + mapped[0] + "," + mapped[1]
+                        + " surface=" + displayW + "x" + displayH
                         + " remote=" + (int) remoteW + "x" + (int) remoteH
                         + " video=" + remote_video_resolution[0] + "x" + remote_video_resolution[1]);
             }
-            sendTouchEvent(touch_event.getAction(), touch_event.getButtonState(), x, y, pointerId);
+            sendTouchEvent(touch_event.getAction(), touch_event.getButtonState(),
+                    mapped[0], mapped[1], pointerId);
         }
         return true;
     }
 
-    private static int mapToRemote(int value, int surfaceSize, float remoteSize) {
-        return (int) (value * remoteSize / surfaceSize);
+    /**
+     * Mappa il tocco dal SurfaceView ai pixel del device remoto, con letterbox
+     * se l'aspect del remoto non coincide con quello del client.
+     */
+    private static int[] mapTouchToRemote(float touchX, float touchY,
+                                          int displayW, int displayH,
+                                          float remoteW, float remoteH) {
+        float scale = Math.min(displayW / remoteW, displayH / remoteH);
+        float contentW = remoteW * scale;
+        float contentH = remoteH * scale;
+        if (contentW <= 0f || contentH <= 0f) {
+            return new int[]{0, 0};
+        }
+        float offX = (displayW - contentW) / 2f;
+        float offY = (displayH - contentH) / 2f;
+        int x = Math.round((touchX - offX) * remoteW / contentW);
+        int y = Math.round((touchY - offY) * remoteH / contentH);
+        if (x < 0) {
+            x = 0;
+        } else if (x >= (int) remoteW) {
+            x = (int) remoteW - 1;
+        }
+        if (y < 0) {
+            y = 0;
+        } else if (y >= (int) remoteH) {
+            y = (int) remoteH - 1;
+        }
+        return new int[]{x, y};
     }
 
     private void sendTouchEvent(int action, int buttonState, int x, int y, int pointerId) {
@@ -222,12 +270,28 @@ public class Scrcpy extends Service {
     }
 
     public int[] getOrientedRemoteSize(boolean landscape) {
-        int a = remote_dev_resolution[0];
-        int b = remote_dev_resolution[1];
-        if (landscape) {
-            return new int[]{Math.max(a, b), Math.min(a, b)};
+        int w = remote_dev_resolution[0];
+        int h = remote_dev_resolution[1];
+        if (w > 0 && h > 0) {
+            return new int[]{w, h};
         }
-        return new int[]{Math.min(a, b), Math.max(a, b)};
+        if (landscape) {
+            return new int[]{Math.max(w, h), Math.min(w, h)};
+        }
+        return new int[]{Math.min(w, h), Math.max(w, h)};
+    }
+
+    public void applyRemoteRotation() {
+        swapPair(remote_dev_resolution);
+        swapPair(remote_video_resolution);
+        Log.i("Scrcpy", "Remote rotation device=" + remote_dev_resolution[0] + "x" + remote_dev_resolution[1]
+                + " video=" + remote_video_resolution[0] + "x" + remote_video_resolution[1]);
+    }
+
+    private static void swapPair(int[] values) {
+        int tmp = values[0];
+        values[0] = values[1];
+        values[1] = tmp;
     }
 
     public boolean check_socket_connection() {
@@ -318,12 +382,6 @@ public class Scrcpy extends Service {
                 remote_video_resolution[1] = handshake[3];
                 Log.i("Scrcpy", "Handshake device=" + handshake[0] + "x" + handshake[1]
                         + " video=" + handshake[2] + "x" + handshake[3]);
-                if (remote_dev_resolution[0] > remote_dev_resolution[1]) {
-                    first_time = false;
-                    int i = remote_dev_resolution[0];
-                    remote_dev_resolution[0] = remote_dev_resolution[1];
-                    remote_dev_resolution[1] = i;
-                }
 
                 socketInputStream = dataInputStream;
                 socketOutputStream = dataOutputStream;
@@ -405,11 +463,17 @@ public class Scrcpy extends Service {
         long lastAudioOffset = 0;
 
         boolean waitKeyFrame = false;
+        boolean pendingConfigure = false;
+        long lastKeyframeRequest = 0;
 
 
         while (LetServceRunning.get()) {
             boolean waitEvent = true;
             try {
+                if (pendingConfigure && tryConfigureVideoDecoder(streamSettings)) {
+                    pendingConfigure = false;
+                    updateAvailable.set(false);
+                }
                 byte[] sendevent;
                 int drained = 0;
                 while ((sendevent = event.poll()) != null) {
@@ -449,72 +513,67 @@ public class Scrcpy extends Service {
                     dataInputStream.readFully(packet, 0, size);
                     if (MediaPacket.Type.getType(packet[0]) == MediaPacket.Type.VIDEO) {
                         VideoPacket videoPacket = VideoPacket.readHead(packet);
-                        // byte[] data = videoPacket.data;
-                        if (videoPacket.flag == VideoPacket.Flag.CONFIG || updateAvailable.get()) {
-                            if (!updateAvailable.get()) {
-                                int dataLength = packet.length - videoPacket.headLength();
-                                byte[] data = new byte[dataLength];
-                                System.arraycopy(packet, videoPacket.headLength(), data, 0, dataLength);
-                                streamSettings = VideoPacket.getStreamSettings(data, "video/hevc".equals(videoMimeType));
-                                if (!first_time) {
-                                    if (serviceCallbacks != null) {
-                                        serviceCallbacks.loadNewRotation();
+                        if (videoPacket.flag == VideoPacket.Flag.CONFIG) {
+                            // Sempre parsare SPS/PPS: setParms/rotazione possono alzare
+                            // updateAvailable prima del primo CONFIG e, se lo saltiamo, lo
+                            // schermo resta nero per sempre (decoder mai configurato).
+                            int dataLength = packet.length - videoPacket.headLength();
+                            byte[] data = new byte[dataLength];
+                            System.arraycopy(packet, videoPacket.headLength(), data, 0, dataLength);
+                            streamSettings = VideoPacket.getStreamSettings(data, "video/hevc".equals(videoMimeType));
+                            pendingConfigure = true;
+                            if (!first_time) {
+                                applyRemoteRotation();
+                                if (serviceCallbacks != null) {
+                                    serviceCallbacks.loadNewRotation();
+                                }
+                                int waitSurface = 40;
+                                while (!updateAvailable.get() && LetServceRunning.get() && waitSurface-- > 0) {
+                                    try {
+                                        Thread.sleep(50);
+                                    } catch (InterruptedException e) {
+                                        e.printStackTrace();
                                     }
-                                    while (!updateAvailable.get()) {
-                                        // Waiting for new surface
-                                        try {
-                                            Thread.sleep(100);
-                                        } catch (InterruptedException e) {
-                                            e.printStackTrace();
-                                        }
-                                    }
-
                                 }
                             }
+                        }
+                        if (pendingConfigure || updateAvailable.get()) {
                             updateAvailable.set(false);
-                            if (streamSettings != null) {
-                                int decodeW = remote_video_resolution[0] > 0
-                                        ? remote_video_resolution[0]
-                                        : (remote_dev_resolution[0] > 0 ? remote_dev_resolution[0] : screenWidth);
-                                int decodeH = remote_video_resolution[1] > 0
-                                        ? remote_video_resolution[1]
-                                        : (remote_dev_resolution[1] > 0 ? remote_dev_resolution[1] : screenHeight);
-                                if (!isSurfaceReady(surface)) {
-                                    Log.e("Scrcpy", "Skipping video configure: surface not ready");
-                                } else {
-                                    Log.i("Scrcpy", "Decoder configure " + decodeW + "x" + decodeH);
-                                    videoDecoder.configure(surface, decodeW, decodeH, streamSettings.sps, streamSettings.pps, videoMimeType);
-                                }
+                            if (tryConfigureVideoDecoder(streamSettings)) {
+                                pendingConfigure = false;
                             }
-                        } else if (videoPacket.flag == VideoPacket.Flag.END) {
+                        }
+                        if (videoPacket.flag == VideoPacket.Flag.END) {
                             // need close stream
                             Log.e("Scrcpy", "END ... ");
-                        } else {
+                        } else if (videoPacket.flag != VideoPacket.Flag.CONFIG) {
                             // Log.e("Scrcpy", "videoPacket presentationTimeStamp ... " + videoPacket.presentationTimeStamp);
                             if (lastVideoOffset == 0) {
                                 lastVideoOffset = System.currentTimeMillis() - (videoPacket.presentationTimeStamp / 1000);
                             }
                             long latencyMs = System.currentTimeMillis() - (lastVideoOffset + (videoPacket.presentationTimeStamp / 1000));
-                            // delay troppo aggressivo = schermo nero permanente: decodifica sempre i keyframe
-                            // e i frame entro la soglia; se in ritardo chiedi un nuovo keyframe ma non bloccare per sempre
+                            // Software encoder: non scartare i P-frame sotto ~1s, altrimenti
+                            // si attende un keyframe e lo specchio sembra lento/a scatti.
                             if (videoPacket.flag == VideoPacket.Flag.KEY_FRAME) {
                                 waitKeyFrame = false;
-                                if (latencyMs > delay * 3L) {
-                                    // stream molto in ritardo: riallinea l'offset e continua
+                                if (latencyMs > 1500) {
                                     lastVideoOffset = System.currentTimeMillis() - (videoPacket.presentationTimeStamp / 1000);
                                 }
                                 videoDecoder.decodeSample(packet, videoPacket.headLength(), packet.length - videoPacket.headLength(),
                                         0, videoPacket.flag.getFlag());
-                            } else {
-                                if (waitKeyFrame) {
-                                    requestNewKeyFrame();
-                                } else if (latencyMs <= Math.max(delay, 200)) {
-                                    videoDecoder.decodeSample(packet, videoPacket.headLength(), packet.length - videoPacket.headLength(),
-                                            0, videoPacket.flag.getFlag());
-                                } else {
-                                    waitKeyFrame = true;
+                            } else if (waitKeyFrame) {
+                                long now = System.currentTimeMillis();
+                                if (now - lastKeyframeRequest > 400) {
+                                    lastKeyframeRequest = now;
                                     requestNewKeyFrame();
                                 }
+                            } else if (latencyMs <= 1500) {
+                                videoDecoder.decodeSample(packet, videoPacket.headLength(), packet.length - videoPacket.headLength(),
+                                        0, videoPacket.flag.getFlag());
+                            } else {
+                                waitKeyFrame = true;
+                                lastKeyframeRequest = System.currentTimeMillis();
+                                requestNewKeyFrame();
                             }
                         }
                         first_time = false;

--- a/app/src/main/java/org/client/scrcpy/ScrcpyHost.java
+++ b/app/src/main/java/org/client/scrcpy/ScrcpyHost.java
@@ -82,7 +82,7 @@ public class ScrcpyHost implements Scrcpy.ServiceCallbacks {
                     remote_device_height = rem_res[1];
                     remote_device_width = rem_res[0];
                     first_time = false;
-                    Log.d("fuck", "onServiceConnected: " + remote_device_height + "|" + remote_device_width);
+                    Log.d("Scrcpy", "onServiceConnected: " + remote_device_height + "x" + remote_device_width);
                     connectCallBack.onConnect(Math.min(remote_device_width, remote_device_height), Math.max(remote_device_width, remote_device_height));
                 }
             } else {

--- a/app/src/main/java/org/client/scrcpy/SendCommands.java
+++ b/app/src/main/java/org/client/scrcpy/SendCommands.java
@@ -16,7 +16,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class SendCommands {
 
-    public final static int WAIT_TIME = 5000;
+    public final static int WAIT_TIME = 15000;
 
     public enum CmdStatus {
         SUCCESS,
@@ -29,29 +29,21 @@ public class SendCommands {
     }
 
     public CmdStatus SendAdbCommands(Context context, final String ip, int port, int forwardport, String localip, int bitrate, int size, boolean enableAudio) {
-        return this.SendAdbCommands(context, null, ip, port, forwardport, localip, bitrate, size, enableAudio);
-    }
-
-    public CmdStatus SendAdbCommands(Context context, final byte[] fileBase64, final String ip, int port, int forwardport, String localip, int bitrate, int size, boolean enableAudio) {
-        AtomicReference<CmdStatus> status = new AtomicReference<>(CmdStatus.RUNNING);
-//        String[] commands = new String[]{
-//                "-s", ip + ":" + port,
-//                "shell",
-//                " CLASSPATH=/data/local/tmp/scrcpy-server.jar",
-//                "app_process",
-//                "/",
-//                "org.server.scrcpy.Server",
-//                "/" + localip,
-//                Long.toString(size),
-//                Long.toString(bitrate) + ";"
-//        };
-        // 更多参数可后续加入
         Options options = new Options();
         options.setIp(localip);
         options.setMaxSize(size);
         options.setBitRate(bitrate);
         options.setTunnelForward(true);
         options.setEnableAudioForward(enableAudio);
+        return SendAdbCommands(context, ip, port, forwardport, options);
+    }
+
+    public CmdStatus SendAdbCommands(Context context, final byte[] fileBase64, final String ip, int port, int forwardport, String localip, int bitrate, int size, boolean enableAudio) {
+        return SendAdbCommands(context, ip, port, forwardport, localip, bitrate, size, enableAudio);
+    }
+
+    public CmdStatus SendAdbCommands(Context context, final String ip, int port, int forwardport, Options options) {
+        AtomicReference<CmdStatus> status = new AtomicReference<>(CmdStatus.RUNNING);
 
         List<String> cmdList = new ArrayList<>();
         Collections.addAll(cmdList,
@@ -93,14 +85,14 @@ public class SendCommands {
                 e.printStackTrace();
             }
         }
-        if (count >= 50) {
+        if (count >= (WAIT_TIME / 100)) {
             status.set(CmdStatus.ERROR);
             return status.get();
         }
         if (status.get() == CmdStatus.SUCCESS) {
             count = 0;
             //  检测程序是否已经启动，如果启动了，该文件会被删除
-            while (status.get() == CmdStatus.SUCCESS && count < 10) {
+            while (status.get() == CmdStatus.SUCCESS && count < 40) {
                 String adbTextCmd = AdbHelper.adbCmd(App.mContext,
                         "-s", ip + ":" + port, "shell", "ls", "-alh", "/data/local/tmp/scrcpy-server.jar");
                 if (TextUtils.isEmpty(adbTextCmd)) {

--- a/app/src/main/java/org/client/scrcpy/decoder/VideoDecoder.java
+++ b/app/src/main/java/org/client/scrcpy/decoder/VideoDecoder.java
@@ -3,6 +3,7 @@ package org.client.scrcpy.decoder;
 import android.media.MediaCodec;
 import android.media.MediaFormat;
 import android.os.Build;
+import android.util.Log;
 import android.view.Surface;
 
 
@@ -11,6 +12,7 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class VideoDecoder {
+    private static final String TAG = "Scrcpy";
     private MediaCodec mCodec;
     private Worker mWorker;
     private AtomicBoolean mIsConfigured = new AtomicBoolean(false);
@@ -59,6 +61,14 @@ public class VideoDecoder {
         }
 
         private void configure(Surface surface, int width, int height, ByteBuffer csd0, ByteBuffer csd1) {
+            if (surface == null) {
+                Log.e(TAG, "VideoDecoder configure skipped: surface is null");
+                return;
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !surface.isValid()) {
+                Log.e(TAG, "VideoDecoder configure skipped: surface is invalid");
+                return;
+            }
             if (mIsConfigured.get()) {
                 mIsConfigured.set(false);
                 if (mCodec != null) {
@@ -124,6 +134,7 @@ public class VideoDecoder {
                     }
                 }
             } catch (IllegalStateException e) {
+                Log.e(TAG, "VideoDecoder output loop failed: " + e.getMessage());
             }
 
         }

--- a/app/src/main/java/org/client/scrcpy/decoder/VideoDecoder.java
+++ b/app/src/main/java/org/client/scrcpy/decoder/VideoDecoder.java
@@ -3,6 +3,7 @@ package org.client.scrcpy.decoder;
 import android.media.MediaCodec;
 import android.media.MediaFormat;
 import android.os.Build;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.Surface;
 
@@ -24,8 +25,12 @@ public class VideoDecoder {
     }
 
     public void configure(Surface surface, int width, int height, ByteBuffer csd0, ByteBuffer csd1) {
+        configure(surface, width, height, csd0, csd1, "video/avc");
+    }
+
+    public void configure(Surface surface, int width, int height, ByteBuffer csd0, ByteBuffer csd1, String mimeType) {
         if (mWorker != null) {
-            mWorker.configure(surface, width, height, csd0, csd1);
+            mWorker.configure(surface, width, height, csd0, csd1, mimeType);
         }
     }
 
@@ -60,7 +65,7 @@ public class VideoDecoder {
             mIsRunning.set(isRunning);
         }
 
-        private void configure(Surface surface, int width, int height, ByteBuffer csd0, ByteBuffer csd1) {
+        private void configure(Surface surface, int width, int height, ByteBuffer csd0, ByteBuffer csd1, String mimeType) {
             if (surface == null) {
                 Log.e(TAG, "VideoDecoder configure skipped: surface is null");
                 return;
@@ -72,17 +77,33 @@ public class VideoDecoder {
             if (mIsConfigured.get()) {
                 mIsConfigured.set(false);
                 if (mCodec != null) {
-                    mCodec.stop();
+                    try {
+                        mCodec.stop();
+                    } catch (IllegalStateException ignore) {
+                    }
+                    try {
+                        mCodec.release();
+                    } catch (IllegalStateException ignore) {
+                    }
+                    mCodec = null;
                 }
 
             }
-            MediaFormat format = MediaFormat.createVideoFormat("video/avc", width, height);
-            format.setByteBuffer("csd-0", csd0);
-            format.setByteBuffer("csd-1", csd1);
+            String mime = TextUtils.isEmpty(mimeType) ? "video/avc" : mimeType;
+            int safeW = Math.max(width, 16);
+            int safeH = Math.max(height, 16);
+            MediaFormat format = MediaFormat.createVideoFormat(mime, safeW, safeH);
+            if (csd0 != null) {
+                format.setByteBuffer("csd-0", csd0);
+            }
+            // H.264 uses SPS/PPS; HEVC prefers a single csd-0 with VPS/SPS/PPS
+            if (csd1 != null && "video/avc".equals(mime)) {
+                format.setByteBuffer("csd-1", csd1);
+            }
             try {
-                mCodec = MediaCodec.createDecoderByType("video/avc");
+                mCodec = MediaCodec.createDecoderByType(mime);
             } catch (IOException e) {
-                throw new RuntimeException("Failed to create codec", e);
+                throw new RuntimeException("Failed to create codec for " + mime, e);
             }
             mCodec.configure(format, surface, null, 0);
             mCodec.start();

--- a/app/src/main/java/org/client/scrcpy/model/VideoPacket.java
+++ b/app/src/main/java/org/client/scrcpy/model/VideoPacket.java
@@ -104,6 +104,18 @@ public class VideoPacket extends MediaPacket<VideoPacket> {
     }
 
     public static StreamSettings getStreamSettings(byte[] buffer) {
+        return getStreamSettings(buffer, false);
+    }
+
+    public static StreamSettings getStreamSettings(byte[] buffer, boolean hevc) {
+        StreamSettings streamSettings = new StreamSettings();
+        if (hevc) {
+            // HEVC MediaCodec expects VPS/SPS/PPS together in csd-0
+            streamSettings.sps = ByteBuffer.wrap(buffer);
+            streamSettings.pps = null;
+            return streamSettings;
+        }
+
         byte[] sps, pps;
 
         ByteBuffer spsPpsBuffer = ByteBuffer.wrap(buffer);
@@ -123,15 +135,8 @@ public class VideoPacket extends MediaPacket<VideoPacket> {
         pps = new byte[buffer.length - ppsIndex];
         System.arraycopy(buffer, ppsIndex, pps, 0, pps.length);
 
-        // sps buffer
-        ByteBuffer spsBuffer = ByteBuffer.wrap(sps, 0, sps.length);
-
-        // pps buffer
-        ByteBuffer ppsBuffer = ByteBuffer.wrap(pps, 0, pps.length);
-
-        StreamSettings streamSettings = new StreamSettings();
-        streamSettings.sps = spsBuffer;
-        streamSettings.pps = ppsBuffer;
+        streamSettings.sps = ByteBuffer.wrap(sps, 0, sps.length);
+        streamSettings.pps = ByteBuffer.wrap(pps, 0, pps.length);
 
         return streamSettings;
     }

--- a/app/src/main/java/org/client/scrcpy/utils/AdbHelper.java
+++ b/app/src/main/java/org/client/scrcpy/utils/AdbHelper.java
@@ -2,6 +2,7 @@ package org.client.scrcpy.utils;
 
 import android.content.Context;
 import android.content.res.AssetManager;
+import android.text.TextUtils;
 import android.util.Log;
 
 import org.client.scrcpy.App;
@@ -148,6 +149,43 @@ public class AdbHelper {
         }
     }
 
+
+    /**
+     * True if the wireless ADB target is listed as {@code device} (not offline/unauthorized).
+     */
+    public static boolean isDeviceOnline(Context mContext, String host, int port) {
+        if (mContext == null || TextUtils.isEmpty(host)) {
+            return false;
+        }
+        String serial = host + ":" + port;
+        if (listedAsOnline(adbCmd(mContext, "devices"), serial)) {
+            return true;
+        }
+        boolean connectFinished = executeWithTimeout(() -> adbCmd(mContext, "connect", serial),
+                4, TimeUnit.SECONDS);
+        if (!connectFinished) {
+            return false;
+        }
+        return listedAsOnline(adbCmd(mContext, "devices"), serial);
+    }
+
+    private static boolean listedAsOnline(String devicesOutput, String serial) {
+        if (TextUtils.isEmpty(devicesOutput) || TextUtils.isEmpty(serial)) {
+            return false;
+        }
+        String[] lines = devicesOutput.split("\\r?\\n");
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (!trimmed.startsWith(serial)) {
+                continue;
+            }
+            String rest = trimmed.substring(serial.length()).trim();
+            if ("device".equals(rest) || rest.startsWith("device ") || rest.startsWith("device\t")) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     public static String adbCmd(Context mContext, String... cmd) {
         return adbCmd(mContext, true, cmd);

--- a/app/src/main/java/org/client/scrcpy/utils/ExecUtil.java
+++ b/app/src/main/java/org/client/scrcpy/utils/ExecUtil.java
@@ -7,6 +7,7 @@ import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Map;
 
@@ -120,8 +121,6 @@ public class ExecUtil {
     public static String adbCommend(String[] cmd, Map<String, String> env, File workDir) {
         Process process = null;
         DataOutputStream os = null;
-        BufferedReader successResult = null;
-        BufferedReader errorResult = null;
         try {
             ProcessBuilder processBuilder = new ProcessBuilder(cmd).directory(workDir);
             Map<String, String> envs = processBuilder.environment();
@@ -131,34 +130,15 @@ public class ExecUtil {
             process = processBuilder.start();
             os = new DataOutputStream(process.getOutputStream());
             os.flush();
-            int result = process.waitFor();
-            // get command result
+            os.close();
+            os = null;
             StringBuilder successMsg = new StringBuilder();
             StringBuilder errorMsg = new StringBuilder();
-            successResult = new BufferedReader(new InputStreamReader(
-                    process.getInputStream()));
-            boolean successFirst = true;
-            errorResult = new BufferedReader(new InputStreamReader(
-                    process.getErrorStream()));
-            boolean errorFirst = true;
-            String s;
-            while ((s = successResult.readLine()) != null) {
-                if (!successFirst) {
-                    successMsg.append("\n");
-                } else {
-                    successFirst = false;
-                }
-                successMsg.append(s);
-            }
-            while ((s = errorResult.readLine()) != null) {
-                if (!errorFirst) {
-                    errorMsg.append("\n");
-                } else {
-                    errorFirst = false;
-                }
-                errorMsg.append(s);
-            }
-            Log.i("Scrcpy", errorMsg.toString());
+            Thread outThread = drainAsync(process.getInputStream(), successMsg, false);
+            Thread errThread = drainAsync(process.getErrorStream(), errorMsg, true);
+            process.waitFor();
+            outThread.join(2000);
+            errThread.join(2000);
             return successMsg.toString();
         } catch (Exception e) {
             Log.i("TaskPrint", e.toString());
@@ -166,12 +146,6 @@ public class ExecUtil {
             try {
                 if (os != null) {
                     os.close();
-                }
-                if (successResult != null) {
-                    successResult.close();
-                }
-                if (errorResult != null) {
-                    errorResult.close();
                 }
             } catch (IOException e) {
                 e.printStackTrace();
@@ -181,6 +155,41 @@ public class ExecUtil {
             }
         }
         return "";
+    }
+
+    private static Thread drainAsync(InputStream stream, StringBuilder sink, boolean logAll) {
+        Thread thread = new Thread(() -> {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
+                String line;
+                boolean first = true;
+                while ((line = reader.readLine()) != null) {
+                    synchronized (sink) {
+                        if (!first) {
+                            sink.append('\n');
+                        }
+                        first = false;
+                        sink.append(line);
+                    }
+                    if (logAll || isServerLogLine(line)) {
+                        Log.i("Scrcpy", line);
+                    }
+                }
+            } catch (IOException ignored) {
+            }
+        }, "adb-drain");
+        thread.setDaemon(true);
+        thread.start();
+        return thread;
+    }
+
+    private static boolean isServerLogLine(String line) {
+        return line.startsWith("INFO:")
+                || line.startsWith("ERROR:")
+                || line.startsWith("WARN:")
+                || line.startsWith("DEBUG:")
+                || line.contains("scrcpy")
+                || line.contains("Display:")
+                || line.contains("Encoder");
     }
 
 }

--- a/app/src/main/java/org/client/scrcpy/utils/ResolutionHelper.java
+++ b/app/src/main/java/org/client/scrcpy/utils/ResolutionHelper.java
@@ -1,0 +1,156 @@
+package org.client.scrcpy.utils;
+
+import android.content.Context;
+import android.util.DisplayMetrics;
+import android.util.Log;
+import android.view.WindowManager;
+
+import org.client.scrcpy.App;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class ResolutionHelper {
+
+    private static final String TAG = "Scrcpy";
+    private static final Pattern SIZE_PATTERN = Pattern.compile("(\\d+)x(\\d+)");
+
+    public enum LimitSource {
+        LOCAL,
+        REMOTE
+    }
+
+    public static final class AutoResolution {
+        public final int maxSize;
+        public final int displayWidth;
+        public final int displayHeight;
+        public final int localMax;
+        public final int remoteWidth;
+        public final int remoteHeight;
+        public final LimitSource limitSource;
+
+        AutoResolution(int maxSize, int displayWidth, int displayHeight,
+                       int localMax, int remoteWidth, int remoteHeight, LimitSource limitSource) {
+            this.maxSize = maxSize;
+            this.displayWidth = displayWidth;
+            this.displayHeight = displayHeight;
+            this.localMax = localMax;
+            this.remoteWidth = remoteWidth;
+            this.remoteHeight = remoteHeight;
+            this.limitSource = limitSource;
+        }
+    }
+
+    public static int getLocalMaxDimension(Context context) {
+        DisplayMetrics metrics = new DisplayMetrics();
+        WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+        if (windowManager == null) {
+            return 0;
+        }
+        windowManager.getDefaultDisplay().getRealMetrics(metrics);
+        return alignTo8(Math.max(metrics.widthPixels, metrics.heightPixels));
+    }
+
+    public static int[] getLocalDisplaySize(Context context) {
+        DisplayMetrics metrics = new DisplayMetrics();
+        WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+        if (windowManager == null) {
+            return new int[]{0, 0};
+        }
+        windowManager.getDefaultDisplay().getRealMetrics(metrics);
+        return new int[]{metrics.widthPixels, metrics.heightPixels};
+    }
+
+    public static int[] queryRemoteDisplaySize(Context context, String serverAdr) {
+        String[] serverInfo = Util.getServerHostAndPort(serverAdr);
+        String device = serverInfo[0] + ":" + serverInfo[1];
+        AdbHelper.adbCmd(App.mContext, "connect", device);
+        String wmSize = AdbHelper.adbCmd(App.mContext, "-s", device, "shell", "wm", "size");
+        Log.i(TAG, "Remote wm size: " + wmSize);
+        return parseWmSizeOutput(wmSize);
+    }
+
+    public static AutoResolution computeAuto(Context context, String serverAdr) {
+        int localMax = getLocalMaxDimension(context);
+        int[] remoteSize = queryRemoteDisplaySize(context, serverAdr);
+        int remoteWidth = alignTo8(remoteSize[0]);
+        int remoteHeight = alignTo8(remoteSize[1]);
+
+        if (remoteWidth <= 0 || remoteHeight <= 0) {
+            Log.w(TAG, "Remote resolution unavailable, using local display only");
+            int[] localSize = getLocalDisplaySize(context);
+            int width = alignTo8(localSize[0]);
+            int height = alignTo8(localSize[1]);
+            int maxSize = alignTo8(Math.max(width, height));
+            return new AutoResolution(maxSize, width, height, localMax, width, height, LimitSource.LOCAL);
+        }
+
+        int remoteMax = Math.max(remoteWidth, remoteHeight);
+        LimitSource limitSource = localMax <= remoteMax ? LimitSource.LOCAL : LimitSource.REMOTE;
+        int maxSize = alignTo8(Math.min(localMax, remoteMax));
+        int[] scaled = scaleToMaxSize(remoteWidth, remoteHeight, maxSize);
+        return new AutoResolution(maxSize, scaled[0], scaled[1], localMax, remoteWidth, remoteHeight, limitSource);
+    }
+
+    /**
+     * Same scaling rules as the scrcpy server ({@code Device.computeScreenInfo}).
+     */
+    public static int[] scaleToMaxSize(int width, int height, int maxSize) {
+        int w = alignTo8(width);
+        int h = alignTo8(height);
+        if (maxSize <= 0) {
+            return new int[]{w, h};
+        }
+        boolean portrait = h > w;
+        int major = portrait ? h : w;
+        int minor = portrait ? w : h;
+        if (major > maxSize) {
+            int minorExact = minor * maxSize / major;
+            minor = alignTo8(minorExact + 4);
+            major = maxSize;
+        }
+        w = portrait ? minor : major;
+        h = portrait ? major : minor;
+        return new int[]{w, h};
+    }
+
+    private static int[] parseWmSizeOutput(String output) {
+        if (output == null) {
+            return new int[]{0, 0};
+        }
+        int[] overrideSize = null;
+        int[] physicalSize = null;
+        for (String line : output.split("\n")) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("Override size:")) {
+                overrideSize = parseSizeLine(trimmed);
+            } else if (trimmed.startsWith("Physical size:")) {
+                physicalSize = parseSizeLine(trimmed);
+            } else if (trimmed.contains("x") && physicalSize == null) {
+                int[] parsed = parseSizeLine(trimmed);
+                if (parsed[0] > 0 && parsed[1] > 0) {
+                    physicalSize = parsed;
+                }
+            }
+        }
+        if (overrideSize != null && overrideSize[0] > 0 && overrideSize[1] > 0) {
+            return overrideSize;
+        }
+        if (physicalSize != null && physicalSize[0] > 0 && physicalSize[1] > 0) {
+            return physicalSize;
+        }
+        return new int[]{0, 0};
+    }
+
+    private static int[] parseSizeLine(String line) {
+        Matcher matcher = SIZE_PATTERN.matcher(line);
+        if (matcher.find()) {
+            return new int[]{Integer.parseInt(matcher.group(1)), Integer.parseInt(matcher.group(2))};
+        }
+        return new int[]{0, 0};
+    }
+
+    private static int alignTo8(int value) {
+        return value & ~7;
+    }
+}

--- a/app/src/main/java/org/client/scrcpy/utils/ResolutionHelper.java
+++ b/app/src/main/java/org/client/scrcpy/utils/ResolutionHelper.java
@@ -29,7 +29,7 @@ public final class ResolutionHelper {
         public final int remoteHeight;
         public final LimitSource limitSource;
 
-        AutoResolution(int maxSize, int displayWidth, int displayHeight,
+        public AutoResolution(int maxSize, int displayWidth, int displayHeight,
                        int localMax, int remoteWidth, int remoteHeight, LimitSource limitSource) {
             this.maxSize = maxSize;
             this.displayWidth = displayWidth;

--- a/app/src/main/java/org/client/scrcpy/utils/SessionLog.java
+++ b/app/src/main/java/org/client/scrcpy/utils/SessionLog.java
@@ -1,0 +1,294 @@
+package org.client.scrcpy.utils;
+
+import android.content.Context;
+import android.os.Build;
+import android.util.Log;
+
+import org.client.scrcpy.BuildConfig;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Session log: reset at every app start, then capture our process logcat.
+ */
+public final class SessionLog {
+
+    private static final String TAG = "Scrcpy";
+    private static final Object LOCK = new Object();
+    private static File logFile;
+    private static final AtomicBoolean started = new AtomicBoolean(false);
+
+    private static final int MAX_LOG_BYTES = 256 * 1024;
+
+    private SessionLog() {
+    }
+
+    public static void resetAndStart(Context context) {
+        synchronized (LOCK) {
+            File dir = new File(context.getExternalFilesDir(null), "logs");
+            if (!dir.exists() && !dir.mkdirs()) {
+                dir = context.getFilesDir();
+            }
+            logFile = new File(dir, "session.log");
+            try (FileOutputStream out = new FileOutputStream(logFile, false)) {
+                String header = "=== Scrcpy session "
+                        + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).format(new Date())
+                        + " ===\n"
+                        + "app=" + BuildConfig.VERSION_NAME + " r" + BuildConfig.VERSION_CODE + "\n"
+                        + "clientSdk=" + Build.VERSION.SDK_INT
+                        + " device=" + Build.MANUFACTURER + " " + Build.MODEL + "\n\n";
+                out.write(header.getBytes("UTF-8"));
+            } catch (Exception e) {
+                Log.e(TAG, "Could not reset session log", e);
+            }
+        }
+        if (started.compareAndSet(false, true)) {
+            startLogcatCollector();
+            Thread.setDefaultUncaughtExceptionHandler((t, e) -> {
+                e("Uncaught on " + t.getName(), e);
+            });
+        }
+        i("Session log reset");
+    }
+
+    public static File getFile() {
+        synchronized (LOCK) {
+            return logFile;
+        }
+    }
+
+    public static String readAll() {
+        File file = getFile();
+        if (file == null || !file.exists()) {
+            return "";
+        }
+        try {
+            byte[] data = new byte[(int) Math.min(file.length(), 512 * 1024)];
+            java.io.FileInputStream in = new java.io.FileInputStream(file);
+            int n = in.read(data);
+            in.close();
+            return n <= 0 ? "" : new String(data, 0, n, "UTF-8");
+        } catch (Exception e) {
+            return "Could not read log: " + e.getMessage();
+        }
+    }
+
+    /** Riassunto corto per WhatsApp (~400 caratteri). Il log intero va solo in allegato. */
+    public static String readPreview() {
+        return buildWhatsAppSummary(readAll());
+    }
+
+    static String buildWhatsAppSummary(String all) {
+        if (all == null || all.isEmpty()) {
+            return "Log vuoto. Allegato scrcpy-session.log";
+        }
+        String app = findAfter(all, "app=", "\n");
+        String device = findAfter(all, "clientSdk=", "\n");
+        String start = findLineContaining(all, "Start clicked");
+        if (start != null) {
+            int idx = start.indexOf("Start clicked");
+            if (idx >= 0) {
+                start = start.substring(idx);
+            }
+        }
+        String errors = collectErrorHints(all);
+        StringBuilder sb = new StringBuilder();
+        if (app != null && !app.isEmpty()) {
+            sb.append(app.trim());
+        }
+        if (device != null && !device.isEmpty()) {
+            if (sb.length() > 0) {
+                sb.append(" | ");
+            }
+            sb.append(device.trim());
+        }
+        if (start != null) {
+            if (sb.length() > 0) {
+                sb.append('\n');
+            }
+            sb.append(start.trim());
+        }
+        if (!errors.isEmpty()) {
+            if (sb.length() > 0) {
+                sb.append('\n');
+            }
+            sb.append(errors);
+        }
+        if (sb.length() == 0) {
+            sb.append("Sessione senza errori evidenti.");
+        }
+        sb.append("\nLog completo: allegato scrcpy-session.log");
+        String text = sb.toString();
+        if (text.length() <= 400) {
+            return text;
+        }
+        return text.substring(0, 397) + "...";
+    }
+
+    private static String collectErrorHints(String all) {
+        String[][] patterns = {
+                {"can't read socket Resolution", "no resolution"},
+                {"createDisplay", "createDisplay missing"},
+                {"CodecException", "MediaCodec fail"},
+                {"Pending dequeue output buffer", "encoder dequeue cancelled"},
+                {"Could not create display", "no virtual display"},
+                {"Display: using DisplayManager", "DisplayManager OK"},
+                {"Display: using SurfaceControl", "SurfaceControl OK"},
+                {"Display: using AUTO_MIRROR", "AUTO_MIRROR OK"},
+                {"Sent device resolution", "resolution sent"},
+                {"Connection Timed out", "timeout"},
+                {"Network OR ADB connection failed", "ADB fail"},
+                {"Uncaught", "crash"},
+        };
+        StringBuilder hints = new StringBuilder();
+        for (String[] p : patterns) {
+            if (all.contains(p[0])) {
+                if (hints.length() > 0) {
+                    hints.append("; ");
+                }
+                hints.append(p[1]);
+            }
+        }
+        return hints.length() == 0 ? "" : "Esito: " + hints;
+    }
+
+    private static String findAfter(String all, String prefix, String end) {
+        int i = all.indexOf(prefix);
+        if (i < 0) {
+            return null;
+        }
+        int from = i + prefix.length();
+        int to = all.indexOf(end, from);
+        if (to < 0) {
+            to = Math.min(all.length(), from + 80);
+        }
+        return prefix + all.substring(from, to);
+    }
+
+    private static String findLineContaining(String all, String token) {
+        int i = all.indexOf(token);
+        if (i < 0) {
+            return null;
+        }
+        int start = all.lastIndexOf('\n', i);
+        int end = all.indexOf('\n', i);
+        if (start < 0) {
+            start = 0;
+        } else {
+            start++;
+        }
+        if (end < 0) {
+            end = all.length();
+        }
+        return all.substring(start, end);
+    }
+
+    public static void i(String message) {
+        Log.i(TAG, message);
+        append("I", message, null);
+    }
+
+    public static void e(String message) {
+        Log.e(TAG, message);
+        append("E", message, null);
+    }
+
+    public static void e(String message, Throwable t) {
+        Log.e(TAG, message, t);
+        append("E", message, t);
+    }
+
+    private static void append(String level, String message, Throwable t) {
+        synchronized (LOCK) {
+            if (logFile == null) {
+                return;
+            }
+            try (FileOutputStream out = new FileOutputStream(logFile, true)) {
+                String time = new SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(new Date());
+                StringBuilder sb = new StringBuilder();
+                sb.append(time).append(' ').append(level).append("/Scrcpy: ").append(message).append('\n');
+                if (t != null) {
+                    StringWriter sw = new StringWriter();
+                    t.printStackTrace(new PrintWriter(sw));
+                    sb.append(sw);
+                }
+                out.write(sb.toString().getBytes("UTF-8"));
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    private static void startLogcatCollector() {
+        Thread thread = new Thread(() -> {
+            java.lang.Process logcat = null;
+            try {
+                logcat = new ProcessBuilder("logcat", "-v", "time", "--pid=" + android.os.Process.myPid())
+                        .redirectErrorStream(true)
+                        .start();
+                BufferedReader reader = new BufferedReader(new InputStreamReader(logcat.getInputStream()));
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (!isUseful(line)) {
+                        continue;
+                    }
+                    synchronized (LOCK) {
+                        if (logFile == null) {
+                            continue;
+                        }
+                        if (logFile.length() > MAX_LOG_BYTES) {
+                            continue;
+                        }
+                        try (FileOutputStream out = new FileOutputStream(logFile, true)) {
+                            out.write((line + "\n").getBytes("UTF-8"));
+                        } catch (Exception ignored) {
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                append("W", "logcat collector failed: " + e.getMessage(), null);
+            } finally {
+                if (logcat != null) {
+                    logcat.destroy();
+                }
+            }
+        }, "session-logcat");
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    private static boolean isUseful(String line) {
+        if (line == null || line.length() > 2000) {
+            return false;
+        }
+        String upper = line.toUpperCase(Locale.US);
+        return line.contains("Scrcpy")
+                || line.contains("scrcpy")
+                || line.contains("/ADB")
+                || line.contains("MediaCodec")
+                || line.contains("AndroidRuntime")
+                || line.contains("ScreenCapture")
+                || line.contains("CCodec")
+                || line.contains("VirtualDisplay")
+                || line.contains("DisplayManager")
+                || line.contains("SurfaceControl")
+                || line.contains("Encoding")
+                || line.contains("FATAL")
+                || upper.contains(" EXCEPTION")
+                || line.contains("Start clicked")
+                || line.contains("org.server.scrcpy")
+                || line.contains("ERROR:")
+                || line.contains("INFO:")
+                || line.contains("WARN:")
+                || line.contains("Sent device resolution")
+                || line.contains("Could not create");
+    }
+}

--- a/app/src/main/res/drawable/status_led.xml
+++ b/app/src/main/res/drawable/status_led.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#E74C3C" />
+    <stroke
+        android:width="2dp"
+        android:color="#80FFFFFF" />
+</shape>

--- a/app/src/main/res/layout-land/surface.xml
+++ b/app/src/main/res/layout-land/surface.xml
@@ -60,6 +60,19 @@
             android:textSize="20sp"
             style="?android:attr/buttonBarButtonStyle" />
 
+        <Button
+            android:id="@+id/power_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="@android:color/background_dark"
+            android:rotation="90"
+            android:textAlignment="center"
+            android:text="@string/power_button"
+            android:textColor="@android:color/white"
+            android:textSize="24sp"
+            style="?android:attr/buttonBarButtonStyle" />
+
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -72,13 +72,38 @@
                 android:paddingRight="10dp"
                 android:paddingBottom="5dp">
 
-                <TextView
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:paddingTop="5dp"
-                    android:text="@string/label_server_ip"
-                    android:textAppearance="@android:style/TextAppearance"
-                    android:textColor="@color/white" />
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:paddingTop="5dp">
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/label_server_ip"
+                        android:textAppearance="@android:style/TextAppearance"
+                        android:textColor="@color/white" />
+
+                    <View
+                        android:id="@+id/status_led"
+                        android:layout_width="16dp"
+                        android:layout_height="16dp"
+                        android:layout_marginLeft="8dp"
+                        android:background="@drawable/status_led" />
+
+                    <TextView
+                        android:id="@+id/status_led_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="6dp"
+                        android:text="@string/status_offline"
+                        android:textColor="@color/status_offline"
+                        android:textSize="13sp"
+                        android:textStyle="bold" />
+                </LinearLayout>
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -422,6 +447,18 @@
                 android:text="@string/action_start"
                 android:textColor="@color/white"
                 android:textSize="16sp" />
+
+            <Button
+                android:id="@+id/button_reboot"
+                android:layout_width="match_parent"
+                android:layout_height="50dp"
+                android:layout_marginLeft="10dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginRight="10dp"
+                android:background="@drawable/btn_selector"
+                android:text="@string/action_reboot"
+                android:textColor="@color/white"
+                android:textSize="15sp" />
 
             <Button
                 android:id="@+id/button_share_log"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -12,18 +12,31 @@
         android:layout_gravity="top"
         android:background="#3C93F0">
 
-        <TextView
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="80dp"
-            android:layout_gravity="center_vertical"
-            android:layout_marginLeft="10dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginRight="10dp"
-            android:layout_marginBottom="5dp"
-            android:gravity="center_vertical"
-            android:padding="20dp"
-            android:text="Scrcpy For Android"
-            android:textColor="@color/white" />
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp">
+
+            <TextView
+                android:id="@+id/app_title"
+                style="@style/AppTitleText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="@string/app_name" />
+
+            <TextView
+                android:id="@+id/app_subtitle"
+                style="@style/AppSubtitleText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:gravity="center"
+                android:text="@string/app_subtitle" />
+        </LinearLayout>
 
     </FrameLayout>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -152,7 +152,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginLeft="20dp"
                     android:layout_marginRight="20dp"
-                    android:entries="@array/options_resolution_values"
+                    android:entries="@array/options_resolution_keys"
                     android:minHeight="48dp"
                     android:textColor="@color/white"
                     tools:ignore="DuplicateSpeakableTextCheck" />
@@ -216,6 +216,70 @@
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:text="@string/label_video_codec"
+                    android:textAppearance="@android:style/TextAppearance"
+                    android:textColor="@color/white"
+                    android:textSize="16sp" />
+
+                <Spinner
+                    android:id="@+id/spinner_video_codec"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="20dp"
+                    android:layout_marginRight="20dp"
+                    android:entries="@array/options_codec_keys"
+                    android:minHeight="48dp"
+                    android:textColor="@color/white" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="10dp"
+                android:layout_marginTop="10dp"
+                android:layout_marginRight="10dp"
+                android:background="@color/btn_color_nomal"
+                android:orientation="vertical"
+                android:paddingLeft="10dp"
+                android:paddingTop="5dp"
+                android:paddingRight="10dp">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/label_video_fps"
+                    android:textAppearance="@android:style/TextAppearance"
+                    android:textColor="@color/white"
+                    android:textSize="16sp" />
+
+                <Spinner
+                    android:id="@+id/spinner_video_fps"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="20dp"
+                    android:layout_marginRight="20dp"
+                    android:entries="@array/options_fps_keys"
+                    android:minHeight="48dp"
+                    android:textColor="@color/white" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="10dp"
+                android:layout_marginTop="10dp"
+                android:layout_marginRight="10dp"
+                android:background="@color/btn_color_nomal"
+                android:orientation="vertical"
+                android:paddingLeft="10dp"
+                android:paddingTop="5dp"
+                android:paddingRight="10dp">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
                     android:text="@string/delay_control"
                     android:textAppearance="@android:style/TextAppearance"
                     android:textColor="@color/white"
@@ -250,7 +314,7 @@
                 android:textColor="@color/white"
                 android:textSize="15sp" />
 
-            <!-- 包含三个Switch的分组容器，默认隐藏 -->
+            <!-- 包含 tre Switch + encoder -->
             <LinearLayout
                 android:id="@+id/layout_more_settings"
                 android:layout_width="match_parent"
@@ -260,6 +324,45 @@
                 android:layout_marginLeft="10dp"
                 android:layout_marginRight="10dp"
                 tools:visibility="visible">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="10dp"
+                    android:layout_marginTop="10dp"
+                    android:layout_marginRight="10dp"
+                    android:background="@color/btn_color_nomal"
+                    android:orientation="vertical"
+                    android:paddingLeft="10dp"
+                    android:paddingTop="5dp"
+                    android:paddingRight="10dp"
+                    android:paddingBottom="10dp">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/label_video_encoder"
+                        android:textAppearance="@android:style/TextAppearance"
+                        android:textColor="@color/white"
+                        android:textSize="15sp" />
+
+                    <EditText
+                        android:id="@+id/editText_video_encoder"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="5dp"
+                        android:background="@drawable/edit_background"
+                        android:gravity="center"
+                        android:hint="@string/hint_video_encoder"
+                        android:importantForAutofill="no"
+                        android:inputType="text"
+                        android:minHeight="48dp"
+                        android:paddingLeft="8dp"
+                        android:paddingRight="8dp"
+                        android:textColor="@color/white"
+                        android:textColorHint="#A8AAB5"
+                        android:textSize="13sp" />
+                </LinearLayout>
 
                 <Switch
                     android:id="@+id/switch0"
@@ -315,12 +418,23 @@
                 android:layout_marginLeft="10dp"
                 android:layout_marginTop="10dp"
                 android:layout_marginRight="10dp"
-                android:layout_marginBottom="20dp"
-                android:layout_weight="1"
                 android:background="@drawable/btn_selector"
                 android:text="@string/action_start"
                 android:textColor="@color/white"
                 android:textSize="16sp" />
+
+            <Button
+                android:id="@+id/button_share_log"
+                android:layout_width="match_parent"
+                android:layout_height="50dp"
+                android:layout_marginLeft="10dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginRight="10dp"
+                android:layout_marginBottom="20dp"
+                android:background="@drawable/btn_selector"
+                android:text="@string/action_share_log"
+                android:textColor="@color/white"
+                android:textSize="15sp" />
         </LinearLayout>
     </ScrollView>
 </FrameLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -461,6 +461,18 @@
                 android:textSize="15sp" />
 
             <Button
+                android:id="@+id/button_power_off"
+                android:layout_width="match_parent"
+                android:layout_height="50dp"
+                android:layout_marginLeft="10dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginRight="10dp"
+                android:background="@drawable/btn_selector"
+                android:text="@string/action_power_off"
+                android:textColor="@color/white"
+                android:textSize="15sp" />
+
+            <Button
                 android:id="@+id/button_share_log"
                 android:layout_width="match_parent"
                 android:layout_height="50dp"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -157,6 +157,17 @@
                     android:textColor="@color/white"
                     tools:ignore="DuplicateSpeakableTextCheck" />
 
+                <TextView
+                    android:id="@+id/text_resolution_info"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="20dp"
+                    android:layout_marginRight="20dp"
+                    android:layout_marginBottom="4dp"
+                    android:textColor="#A8C8E8"
+                    android:textSize="13sp"
+                    android:visibility="gone" />
+
             </LinearLayout>
 
             <LinearLayout

--- a/app/src/main/res/layout/surface.xml
+++ b/app/src/main/res/layout/surface.xml
@@ -85,6 +85,17 @@
             android:textColor="@android:color/white"
             android:textSize="24sp" />
 
+        <Button
+            android:id="@+id/power_button"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="50dp"
+            android:layout_weight="1"
+            android:background="@drawable/btn_selector"
+            android:text="@string/power_button"
+            android:textAlignment="center"
+            android:textColor="@android:color/white"
+            android:textSize="24sp" />
 
     </LinearLayout>
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -16,10 +16,15 @@
   <string name="label_x">x</string>
   <string name="action_start">開始</string>
   <string name="action_reboot">Android を再起動 (ADB)</string>
+  <string name="action_power_off">Android を電源オフ (ADB)</string>
   <string name="reboot_title">デバイス再起動</string>
   <string name="reboot_ask">ADB で %1$s を再起動しますか？\nデバイスは電源オフ後に再起動します。</string>
   <string name="reboot_wait">reboot コマンドを送信中…</string>
   <string name="reboot_sent">%1$s に reboot コマンドを送信しました</string>
+  <string name="power_off_title">デバイス電源オフ</string>
+  <string name="power_off_ask">ADB で %1$s を電源オフしますか？\nデバイスは完全にシャットダウンします。</string>
+  <string name="power_off_wait">電源オフコマンドを送信中…</string>
+  <string name="power_off_sent">%1$s に電源オフコマンドを送信しました</string>
   <string name="action_share_log">ログを送信 (メール / WhatsApp / …)</string>
   <string name="share_log_subject">Scrcpy log %1$s r%2$d</string>
   <string name="share_log_empty">ログが空です</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -22,10 +22,19 @@
   <string name="disconnect_ask">接続が切断されたことを検出しました。終了して再接続してください。</string>
   <string name="need_register">登録が必要です</string>
     <string name="more_settings">详细设置 ▼</string>
-    <string name="collapse_settings">闭じる ▲</string>
+    <string name="collapse_settings">Collapse Settings ▲</string>
+
+    <string name="resolution_auto">自動</string>
+    <string name="resolution_auto_need_ip">リモート IP を入力して解像度を検出</string>
+    <string name="resolution_auto_detecting">最適な解像度を検出中…</string>
+    <string name="resolution_auto_failed">リモート解像度を検出できませんでした</string>
+    <string name="resolution_auto_local">%1$dx%2$d — ローカル画面で制限</string>
+    <string name="resolution_auto_remote">%1$dx%2$d — リモートデバイスで制限</string>
+    <string name="resolution_auto_stream_local">ストリーム %1$dx%2$d（ローカル画面制限）</string>
+    <string name="resolution_auto_stream_remote">ストリーム %1$dx%2$d（リモートデバイス制限）</string>
 
   <string-array name="options_resolution_values">
-    <item>1920x1080</item>
+    <item>自動</item>
     <item>1600x720</item>
     <item>1280x720</item>
     <item>1200x540</item>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <string name="app_name">ScrcpyForAndroid</string>
+  <string name="app_name">Scrcpy for Android</string>
+  <string name="app_subtitle">リモートデバイスをミラーリング</string>
   <string name="label_server_ip">リモートデバイス IP アドレス、例: 192.168.0.73</string>
   <string name="label_video_resolution">解像度</string>
   <string name="delay_control">遅延コントロール</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -2,18 +2,26 @@
 <resources>
   <string name="app_name">Scrcpy for Android</string>
   <string name="app_subtitle">リモートデバイスをミラーリング</string>
-  <string name="label_server_ip">リモートデバイス IP アドレス、例: 192.168.0.73</string>
-  <string name="label_video_resolution">解像度</string>
+  <string name="app_title">Scrcpy For Android</string>
+  <string name="label_server_ip">リモートデバイス IP（例: 192.168.1.4 または 192.168.1.4:5555）</string>
+  <string name="label_video_resolution">解像度 / 最大サイズ</string>
   <string name="delay_control">遅延コントロール</string>
-  <string name="label_video_bitrate">ビットレート</string>
+  <string name="label_video_bitrate">ビットレート (-b)</string>
+  <string name="label_video_codec">ビデオコーデック</string>
+  <string name="label_video_fps">最大 FPS</string>
+  <string name="label_video_encoder">ビデオエンコーダ（任意）</string>
+  <string name="hint_video_encoder">例: c2.android.avc.encoder（空=デフォルト）</string>
   <string name="label_x">x</string>
   <string name="action_start">開始</string>
+  <string name="action_share_log">ログを送信 (メール / WhatsApp / …)</string>
+  <string name="share_log_subject">Scrcpy log %1$s r%2$d</string>
+  <string name="share_log_empty">ログが空です</string>
   <string name="appswitch_button">=</string>
   <string name="home_button">o</string>
   <string name="back_button">\u003C</string>
   <string name="switch0">ビューイングモード (コントロールなし)</string>
   <string name="switch1">下部のコントロールボタン (戻るボタン)</string>
-    <string name="switch_audio">音声転送を有効にしますか</string>
+  <string name="switch_audio">音声転送を有効にしますか</string>
   <string name="connect_tips">ヒント: デバイスでワイヤレスデバッグを有効化する必要があります。\n\t\tadb ポートコマンドのリセット: adb tcpip 5555</string>
   <string name="please_wait">接続中 …</string>
   <string name="connect_faild">接続に失敗しました</string>
@@ -21,25 +29,43 @@
   <string name="disconnect">切断</string>
   <string name="disconnect_ask">接続が切断されたことを検出しました。終了して再接続してください。</string>
   <string name="need_register">登録が必要です</string>
-    <string name="more_settings">详细设置 ▼</string>
-    <string name="collapse_settings">Collapse Settings ▲</string>
+  <string name="more_settings">详细设置 ▼</string>
+  <string name="collapse_settings">閉じる ▲</string>
 
-    <string name="resolution_auto">自動</string>
-    <string name="resolution_auto_need_ip">リモート IP を入力して解像度を検出</string>
-    <string name="resolution_auto_detecting">最適な解像度を検出中…</string>
-    <string name="resolution_auto_failed">リモート解像度を検出できませんでした</string>
-    <string name="resolution_auto_local">%1$dx%2$d — ローカル画面で制限</string>
-    <string name="resolution_auto_remote">%1$dx%2$d — リモートデバイスで制限</string>
-    <string name="resolution_auto_stream_local">ストリーム %1$dx%2$d（ローカル画面制限）</string>
-    <string name="resolution_auto_stream_remote">ストリーム %1$dx%2$d（リモートデバイス制限）</string>
+  <string name="resolution_auto">自動</string>
+  <string name="resolution_auto_need_ip">リモート IP を入力して解像度を検出</string>
+  <string name="resolution_auto_detecting">最適な解像度を検出中…</string>
+  <string name="resolution_auto_failed">リモート解像度を検出できませんでした</string>
+  <string name="resolution_auto_local">%1$dx%2$d — ローカル画面で制限</string>
+  <string name="resolution_auto_remote">%1$dx%2$d — リモートデバイスで制限</string>
+  <string name="resolution_auto_stream_local">ストリーム %1$dx%2$d（ローカル画面制限）</string>
+  <string name="resolution_auto_stream_remote">ストリーム %1$dx%2$d（リモートデバイス制限）</string>
 
-  <string-array name="options_resolution_values">
-    <item>自動</item>
-    <item>1600x720</item>
+
+  <string-array name="options_resolution_keys">
+    <item>自動 (ネイティブ)</item>
+    <item>1920</item>
+    <item>1600</item>
+    <item>1280</item>
+    <item>1024</item>
+    <item>960</item>
+    <item>800</item>
+    <item>640</item>
+    <item>1920x1080</item>
     <item>1280x720</item>
-    <item>1200x540</item>
-    <item>960x720</item>
-    <item>800x448</item>
+    <item>640x360</item>
+  </string-array>
+  <string-array name="options_resolution_values">
+    <item>0</item>
+    <item>1920</item>
+    <item>1600</item>
+    <item>1280</item>
+    <item>1024</item>
+    <item>960</item>
+    <item>800</item>
+    <item>640</item>
+    <item>1920x1080</item>
+    <item>1280x720</item>
     <item>640x360</item>
   </string-array>
   <string-array name="options_delay_keys">
@@ -53,15 +79,37 @@
     <item>30</item>
   </integer-array>
   <string-array name="options_bitrate_keys">
+    <item>8 Mbps</item>
     <item>6 Mbps</item>
     <item>4 Mbps</item>
     <item>2 Mbps</item>
     <item>1 Mbps</item>
+    <item>512 Kbps</item>
   </string-array>
   <integer-array name="options_bitrate_values">
+    <item>8388608</item>
     <item>6144000</item>
     <item>4096000</item>
     <item>2048000</item>
     <item>1024000</item>
+    <item>524288</item>
+  </integer-array>
+  <string-array name="options_codec_keys">
+    <item>H.264 (avc)</item>
+    <item>H.265 (hevc)</item>
+  </string-array>
+  <string-array name="options_codec_values">
+    <item>h264</item>
+    <item>h265</item>
+  </string-array>
+  <string-array name="options_fps_keys">
+    <item>60 fps</item>
+    <item>30 fps</item>
+    <item>15 fps</item>
+  </string-array>
+  <integer-array name="options_fps_values">
+    <item>60</item>
+    <item>30</item>
+    <item>15</item>
   </integer-array>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -4,6 +4,8 @@
   <string name="app_subtitle">リモートデバイスをミラーリング</string>
   <string name="app_title">Scrcpy For Android</string>
   <string name="label_server_ip">リモートデバイス IP（例: 192.168.1.4 または 192.168.1.4:5555）</string>
+  <string name="status_online">オンライン</string>
+  <string name="status_offline">オフライン</string>
   <string name="label_video_resolution">解像度 / 最大サイズ</string>
   <string name="delay_control">遅延コントロール</string>
   <string name="label_video_bitrate">ビットレート (-b)</string>
@@ -13,6 +15,11 @@
   <string name="hint_video_encoder">例: c2.android.avc.encoder（空=デフォルト）</string>
   <string name="label_x">x</string>
   <string name="action_start">開始</string>
+  <string name="action_reboot">Android を再起動 (ADB)</string>
+  <string name="reboot_title">デバイス再起動</string>
+  <string name="reboot_ask">ADB で %1$s を再起動しますか？\nデバイスは電源オフ後に再起動します。</string>
+  <string name="reboot_wait">reboot コマンドを送信中…</string>
+  <string name="reboot_sent">%1$s に reboot コマンドを送信しました</string>
   <string name="action_share_log">ログを送信 (メール / WhatsApp / …)</string>
   <string name="share_log_subject">Scrcpy log %1$s r%2$d</string>
   <string name="share_log_empty">ログが空です</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -4,6 +4,8 @@
     <string name="app_title">Scrcpy For Android</string>
 
     <string name="label_server_ip">手机的IP地址,例如: 192.168.1.4 或 192.168.1.4:5555</string>
+    <string name="status_online">在线</string>
+    <string name="status_offline">离线</string>
     <string name="label_video_resolution">分辨率 / 最大尺寸</string>
     <string name="delay_control">延迟控制</string>
     <string name="label_video_bitrate">码率 (-b)</string>
@@ -13,6 +15,11 @@
     <string name="hint_video_encoder">例如 c2.android.avc.encoder (空=默认)</string>
     <string name="label_x">x</string>
     <string name="action_start">启动连接</string>
+    <string name="action_reboot">重启 Android (ADB)</string>
+    <string name="reboot_title">重启设备</string>
+    <string name="reboot_ask">通过 ADB 重启 %1$s？\n设备将会关机并重新开机。</string>
+    <string name="reboot_wait">正在发送 reboot 命令…</string>
+    <string name="reboot_sent">已向 %1$s 发送 reboot 命令</string>
     <string name="action_share_log">发送日志 (邮件 / WhatsApp / …)</string>
     <string name="share_log_subject">Scrcpy log %1$s r%2$d</string>
     <string name="share_log_empty">日志为空</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1,13 +1,21 @@
 <resources>
     <string name="app_name">安卓控</string>
     <string name="app_subtitle">远程设备镜像与控制</string>
+    <string name="app_title">Scrcpy For Android</string>
 
-    <string name="label_server_ip">手机的IP地址,例如: 192.168.0.73</string>
-    <string name="label_video_resolution">传输分辨率</string>
+    <string name="label_server_ip">手机的IP地址,例如: 192.168.1.4 或 192.168.1.4:5555</string>
+    <string name="label_video_resolution">分辨率 / 最大尺寸</string>
     <string name="delay_control">延迟控制</string>
-    <string name="label_video_bitrate">带宽码率</string>
+    <string name="label_video_bitrate">码率 (-b)</string>
+    <string name="label_video_codec">视频编码</string>
+    <string name="label_video_fps">最大帧率</string>
+    <string name="label_video_encoder">视频编码器 (可选)</string>
+    <string name="hint_video_encoder">例如 c2.android.avc.encoder (空=默认)</string>
     <string name="label_x">x</string>
     <string name="action_start">启动连接</string>
+    <string name="action_share_log">发送日志 (邮件 / WhatsApp / …)</string>
+    <string name="share_log_subject">Scrcpy log %1$s r%2$d</string>
+    <string name="share_log_empty">日志为空</string>
     <string name="appswitch_button">=</string>
     <string name="home_button">o</string>
     <string name="back_button">\u003C</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -16,10 +16,15 @@
     <string name="label_x">x</string>
     <string name="action_start">启动连接</string>
     <string name="action_reboot">重启 Android (ADB)</string>
+    <string name="action_power_off">关机 Android (ADB)</string>
     <string name="reboot_title">重启设备</string>
     <string name="reboot_ask">通过 ADB 重启 %1$s？\n设备将会关机并重新开机。</string>
     <string name="reboot_wait">正在发送 reboot 命令…</string>
     <string name="reboot_sent">已向 %1$s 发送 reboot 命令</string>
+    <string name="power_off_title">关闭设备</string>
+    <string name="power_off_ask">通过 ADB 关闭 %1$s？\n设备将完全关机。</string>
+    <string name="power_off_wait">正在发送关机命令…</string>
+    <string name="power_off_sent">已向 %1$s 发送关机命令</string>
     <string name="action_share_log">发送日志 (邮件 / WhatsApp / …)</string>
     <string name="share_log_subject">Scrcpy log %1$s r%2$d</string>
     <string name="share_log_empty">日志为空</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -27,6 +27,15 @@
 
     <string name="more_settings">更多设置 ▼</string>
     <string name="collapse_settings">收起设置 ▲</string>
+
+    <string name="resolution_auto">自动</string>
+    <string name="resolution_auto_need_ip">输入远程 IP 以检测分辨率</string>
+    <string name="resolution_auto_detecting">正在检测最佳分辨率…</string>
+    <string name="resolution_auto_failed">无法检测远程分辨率</string>
+    <string name="resolution_auto_local">%1$dx%2$d — 受本地屏幕限制</string>
+    <string name="resolution_auto_remote">%1$dx%2$d — 受远程设备限制</string>
+    <string name="resolution_auto_stream_local">正在传输 %1$dx%2$d（本地屏幕限制）</string>
+    <string name="resolution_auto_stream_remote">正在传输 %1$dx%2$d（远程设备限制）</string>
 </resources>
 
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">安卓控</string>
+    <string name="app_subtitle">远程设备镜像与控制</string>
 
     <string name="label_server_ip">手机的IP地址,例如: 192.168.0.73</string>
     <string name="label_video_resolution">传输分辨率</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -5,6 +5,9 @@
 
     <color name="status_bar">#3C93F0</color>
 
+    <color name="status_online">#2ECC71</color>
+    <color name="status_offline">#E74C3C</color>
+
     <color name="btn_color_nomal">#323540</color>
 
     <color name="theme_color">#1D2228</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,13 +1,21 @@
 <resources>
     <string name="app_name">Scrcpy for Android</string>
     <string name="app_subtitle">Mirror and control remote devices</string>
+    <string name="app_title">Scrcpy For Android</string>
 
-    <string name="label_server_ip">Remote Device IP address, For example: 192.168.0.73</string>
-    <string name="label_video_resolution">Resolution</string>
+    <string name="label_server_ip">Remote Device IP (es. 192.168.1.4 oppure 192.168.1.4:5555)</string>
+    <string name="label_video_resolution">Max size / risoluzione</string>
     <string name="delay_control">Delay Control</string>
-    <string name="label_video_bitrate">Bitrate</string>
+    <string name="label_video_bitrate">Bitrate (-b)</string>
+    <string name="label_video_codec">Video codec</string>
+    <string name="label_video_fps">Max FPS</string>
+    <string name="label_video_encoder">Video encoder (opzionale)</string>
+    <string name="hint_video_encoder">es. c2.android.avc.encoder (vuoto = default)</string>
     <string name="label_x">x</string>
     <string name="action_start">Start</string>
+    <string name="action_share_log">Invia log (email / WhatsApp / …)</string>
+    <string name="share_log_subject">Scrcpy log %1$s r%2$d</string>
+    <string name="share_log_empty">Log vuoto</string>
     <string name="appswitch_button">=</string>
     <string name="home_button">o</string>
     <string name="back_button">\u003C</string>
@@ -38,13 +46,31 @@
     <string name="resolution_auto_stream_local">Streaming %1$dx%2$d (local display limit)</string>
     <string name="resolution_auto_stream_remote">Streaming %1$dx%2$d (remote device limit)</string>
 
-    <string-array name="options_resolution_values">
-        <item>Auto</item>
-        <item>1600x720</item>
+    <!-- 0 = Auto (risoluzione adattata al device remoto) -->
+    <string-array name="options_resolution_keys">
+        <item>Auto (nativo)</item>
+        <item>1920 (lato lungo)</item>
+        <item>1600</item>
+        <item>1280</item>
+        <item>1024</item>
+        <item>960</item>
+        <item>800</item>
+        <item>640</item>
+        <item>1920x1080</item>
         <item>1280x720</item>
-        <item>1200x540</item>
-        <item>960x720</item>
-        <item>800x448</item>
+        <item>640x360</item>
+    </string-array>
+    <string-array name="options_resolution_values">
+        <item>0</item>
+        <item>1920</item>
+        <item>1600</item>
+        <item>1280</item>
+        <item>1024</item>
+        <item>960</item>
+        <item>800</item>
+        <item>640</item>
+        <item>1920x1080</item>
+        <item>1280x720</item>
         <item>640x360</item>
     </string-array>
 
@@ -61,19 +87,43 @@
     </integer-array>
 
     <string-array name="options_bitrate_keys">
+        <item>8 Mbps</item>
         <item>6 Mbps</item>
         <item>4 Mbps</item>
         <item>2 Mbps</item>
         <item>1 Mbps</item>
+        <item>512 Kbps</item>
     </string-array>
 
     <integer-array name="options_bitrate_values">
+        <item>8388608</item>
         <item>6144000</item>
         <item>4096000</item>
         <item>2048000</item>
         <item>1024000</item>
+        <item>524288</item>
+    </integer-array>
+
+    <string-array name="options_codec_keys">
+        <item>H.264 (avc)</item>
+        <item>H.265 (hevc)</item>
+    </string-array>
+
+    <string-array name="options_codec_values">
+        <item>h264</item>
+        <item>h265</item>
+    </string-array>
+
+    <string-array name="options_fps_keys">
+        <item>60 fps</item>
+        <item>30 fps</item>
+        <item>15 fps</item>
+    </string-array>
+
+    <integer-array name="options_fps_values">
+        <item>60</item>
+        <item>30</item>
+        <item>15</item>
     </integer-array>
 
 </resources>
-
-

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,7 @@
     <string name="appswitch_button">=</string>
     <string name="home_button">o</string>
     <string name="back_button">\u003C</string>
+    <string name="power_button">\u23FB</string>
     <string name="switch0">Viewing mode (no control)</string>
     <string name="switch1">Bottom control button (back button)</string>
     <string name="switch_audio">Enable audio forwarding</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
-    <string name="app_name">ScrcpyForAndroid</string>
+    <string name="app_name">Scrcpy for Android</string>
+    <string name="app_subtitle">Mirror and control remote devices</string>
 
     <string name="label_server_ip">Remote Device IP address, For example: 192.168.0.73</string>
     <string name="label_video_resolution">Resolution</string>
@@ -39,7 +40,7 @@
     </string-array>
 
     <string-array name="options_delay_keys">
-        <item>Hight (100ms)</item>
+        <item>High (100ms)</item>
         <item>Medium (60ms)</item>
         <item>Low (30ms)</item>
     </string-array>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,10 +16,15 @@
     <string name="label_x">x</string>
     <string name="action_start">Start</string>
     <string name="action_reboot">Riavvia Android (ADB)</string>
+    <string name="action_power_off">Spegni Android (ADB)</string>
     <string name="reboot_title">Riavvio dispositivo</string>
     <string name="reboot_ask">Riavviare %1$s via ADB?\nIl dispositivo si spegnerà e si riaccenderà.</string>
     <string name="reboot_wait">Invio comando reboot…</string>
     <string name="reboot_sent">Comando reboot inviato a %1$s</string>
+    <string name="power_off_title">Spegnimento dispositivo</string>
+    <string name="power_off_ask">Spegnere %1$s via ADB?\nIl dispositivo si spegnerà completamente.</string>
+    <string name="power_off_wait">Invio comando spegnimento…</string>
+    <string name="power_off_sent">Comando spegnimento inviato a %1$s</string>
     <string name="action_share_log">Invia log (email / WhatsApp / …)</string>
     <string name="share_log_subject">Scrcpy log %1$s r%2$d</string>
     <string name="share_log_empty">Log vuoto</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,8 +29,17 @@
     <string name="more_settings">More Settings ▼</string>
     <string name="collapse_settings">Collapse Settings ▲</string>
 
+    <string name="resolution_auto">Auto</string>
+    <string name="resolution_auto_need_ip">Enter remote IP to detect resolution</string>
+    <string name="resolution_auto_detecting">Detecting optimal resolution…</string>
+    <string name="resolution_auto_failed">Could not detect remote resolution</string>
+    <string name="resolution_auto_local">%1$dx%2$d — limited by local display</string>
+    <string name="resolution_auto_remote">%1$dx%2$d — limited by remote device</string>
+    <string name="resolution_auto_stream_local">Streaming %1$dx%2$d (local display limit)</string>
+    <string name="resolution_auto_stream_remote">Streaming %1$dx%2$d (remote device limit)</string>
+
     <string-array name="options_resolution_values">
-        <item>1920x1080</item>
+        <item>Auto</item>
         <item>1600x720</item>
         <item>1280x720</item>
         <item>1200x540</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
     <string name="app_title">Scrcpy For Android</string>
 
     <string name="label_server_ip">Remote Device IP (es. 192.168.1.4 oppure 192.168.1.4:5555)</string>
+    <string name="status_online">Online</string>
+    <string name="status_offline">Offline</string>
     <string name="label_video_resolution">Max size / risoluzione</string>
     <string name="delay_control">Delay Control</string>
     <string name="label_video_bitrate">Bitrate (-b)</string>
@@ -13,6 +15,11 @@
     <string name="hint_video_encoder">es. c2.android.avc.encoder (vuoto = default)</string>
     <string name="label_x">x</string>
     <string name="action_start">Start</string>
+    <string name="action_reboot">Riavvia Android (ADB)</string>
+    <string name="reboot_title">Riavvio dispositivo</string>
+    <string name="reboot_ask">Riavviare %1$s via ADB?\nIl dispositivo si spegnerà e si riaccenderà.</string>
+    <string name="reboot_wait">Invio comando reboot…</string>
+    <string name="reboot_sent">Comando reboot inviato a %1$s</string>
     <string name="action_share_log">Invia log (email / WhatsApp / …)</string>
     <string name="share_log_subject">Scrcpy log %1$s r%2$d</string>
     <string name="share_log_empty">Log vuoto</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -19,4 +19,16 @@
     <style name="mySpinnerItemStyle" parent="@android:style/Widget.Holo.DropDownItem.Spinner">
         <item name="android:textColor">@color/white</item>
     </style>
+
+    <style name="AppTitleText">
+        <item name="android:textColor">@color/white</item>
+        <item name="android:textSize">22sp</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:letterSpacing">0.02</item>
+    </style>
+
+    <style name="AppSubtitleText">
+        <item name="android:textColor">#D0E8FF</item>
+        <item name="android:textSize">13sp</item>
+    </style>
 </resources>

--- a/app/src/scrcpy/AndroidManifest.xml
+++ b/app/src/scrcpy/AndroidManifest.xml
@@ -16,7 +16,8 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:resizeableActivity="true">
+            android:resizeableActivity="true"
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/server/src/main/java/org/server/scrcpy/Device.java
+++ b/server/src/main/java/org/server/scrcpy/Device.java
@@ -10,9 +10,14 @@ import org.server.scrcpy.wrappers.ServiceManager;
 
 public final class Device {
 
+    private static final int DISPLAY_ID_DEFAULT = 0;
+
     // private final ServiceManager serviceManager = new ServiceManager();
     private ScreenInfo screenInfo;
     private RotationListener rotationListener;
+    private int displayId = DISPLAY_ID_DEFAULT;
+    private int layerStack;
+    private int densityDpi = 160;
 
     public Device(Options options) {
         screenInfo = computeScreenInfo(options.getMaxSize());
@@ -35,6 +40,18 @@ public final class Device {
         return Build.MODEL;
     }
 
+    public int getDisplayId() {
+        return displayId;
+    }
+
+    public int getLayerStack() {
+        return layerStack;
+    }
+
+    public int getDensityDpi() {
+        return densityDpi;
+    }
+
     public synchronized ScreenInfo getScreenInfo() {
         return screenInfo;
     }
@@ -46,28 +63,20 @@ public final class Device {
         // - scale down the great side of the screen to maxSize (if necessary);
         // - scale down the other side so that the aspect ratio is preserved;
         // - round this value to the nearest multiple of 8 (H.264 only accepts multiples of 8)
-        DisplayInfo displayInfo = ServiceManager.getDisplayManager().getDisplayInfo();
+        DisplayInfo displayInfo;
+        try {
+            displayInfo = ServiceManager.getDisplayManager().getDisplayInfo(DISPLAY_ID_DEFAULT);
+        } catch (Exception e) {
+            displayInfo = ServiceManager.getDisplayManager().getDisplayInfo();
+        }
+        displayId = displayInfo.getDisplayId();
+        layerStack = displayInfo.getLayerStack();
+        densityDpi = displayInfo.getDensityDpi();
         boolean rotated = (displayInfo.getRotation() & 1) != 0;
         Size deviceSize = displayInfo.getSize();
-        int w = deviceSize.getWidth() & ~7; // in case it's not a multiple of 8
-        int h = deviceSize.getHeight() & ~7;
-        if (maxSize > 0) {
-            if (BuildConfig.DEBUG && maxSize % 8 != 0) {
-                throw new AssertionError("Max size must be a multiple of 8");
-            }
-            boolean portrait = h > w;
-            int major = portrait ? h : w;
-            int minor = portrait ? w : h;
-            if (major > maxSize) {
-                int minorExact = minor * maxSize / major;
-                // +4 to round the value to the nearest multiple of 8
-                minor = (minorExact + 4) & ~7;
-                major = maxSize;
-            }
-            w = portrait ? minor : major;
-            h = portrait ? major : minor;
-        }
-        Size videoSize = new Size(w, h);
+        Size videoSize = deviceSize.scaleTo(maxSize);
+        Ln.i("Screen size device=" + deviceSize.getWidth() + "x" + deviceSize.getHeight()
+                + " video=" + videoSize.getWidth() + "x" + videoSize.getHeight());
         return new ScreenInfo(deviceSize, videoSize, rotated);
     }
 
@@ -89,7 +98,14 @@ public final class Device {
     }
 
     public boolean injectInputEvent(InputEvent inputEvent, int mode) {
-        return ServiceManager.getInputManager().injectInputEvent(inputEvent, mode);
+        if (!org.server.scrcpy.wrappers.InputManager.setDisplayId(inputEvent, displayId)) {
+            Ln.w("Could not set displayId=" + displayId + " on input event");
+        }
+        boolean ok = ServiceManager.getInputManager().injectInputEvent(inputEvent, mode);
+        if (!ok) {
+            Ln.w("injectInputEvent failed displayId=" + displayId);
+        }
+        return ok;
     }
 
     public boolean isScreenOn() {
@@ -105,16 +121,8 @@ public final class Device {
     }
 
     public Point NewgetPhysicalPoint(Point point) {
-        @SuppressWarnings("checkstyle:HiddenField") // it hides the field on purpose, to read it with a lock
-                ScreenInfo screenInfo = getScreenInfo(); // read with synchronization
-        Size videoSize = screenInfo.getVideoSize();
-//        Size clientVideoSize = position.getScreenSize();
-
-        Size deviceSize = screenInfo.getDeviceSize();
-//        Point point = position.getPoint();
-        int scaledX = point.getX() * deviceSize.getWidth() / videoSize.getWidth();
-        int scaledY = point.getY() * deviceSize.getHeight() / videoSize.getHeight();
-        return new Point(scaledX, scaledY);
+        // Il client mappa già i tocchi in pixel del device remoto.
+        return point;
     }
 
 

--- a/server/src/main/java/org/server/scrcpy/DisplayInfo.java
+++ b/server/src/main/java/org/server/scrcpy/DisplayInfo.java
@@ -6,6 +6,7 @@ public final class DisplayInfo {
     private final int rotation;
     private int layerStack;
     private int flags;
+    private int densityDpi = 160;
 
     public static final int FLAG_SUPPORTS_PROTECTED_BUFFERS = 0x00000001;
 
@@ -15,11 +16,16 @@ public final class DisplayInfo {
     }
 
     public DisplayInfo(int displayId, Size size, int rotation, int layerStack, int flags) {
+        this(displayId, size, rotation, layerStack, flags, 160);
+    }
+
+    public DisplayInfo(int displayId, Size size, int rotation, int layerStack, int flags, int densityDpi) {
         this.displayId = displayId;
         this.size = size;
         this.rotation = rotation;
         this.layerStack = layerStack;
         this.flags = flags;
+        this.densityDpi = densityDpi > 0 ? densityDpi : 160;
     }
 
     public int getDisplayId() {
@@ -40,6 +46,10 @@ public final class DisplayInfo {
 
     public int getFlags() {
         return flags;
+    }
+
+    public int getDensityDpi() {
+        return densityDpi;
     }
 }
 

--- a/server/src/main/java/org/server/scrcpy/EventController.java
+++ b/server/src/main/java/org/server/scrcpy/EventController.java
@@ -69,7 +69,8 @@ public class EventController {
 
             MotionEvent.PointerCoords coords = new MotionEvent.PointerCoords();
             coords.orientation = 0;
-            coords.size = 0;
+            coords.size = 1f;
+            coords.pressure = 1f;
 
             pointerProperties[i] = props;
             pointerCoords[i] = coords;
@@ -90,12 +91,10 @@ public class EventController {
         int[] buffer = controlByteToIntArray(buf);
 
         long now = SystemClock.uptimeMillis();
-        if (buffer.length == 1) {
-            injectKeycode(buffer[0]);
-        } else if (buffer[2] == 0 && buffer[3] == 0) {
-            if (buffer[0] == 28) {
+        if (buffer.length == 1 || (buffer.length < 5 && buffer.length >= 4 && buffer[2] == 0 && buffer[3] == 0)) {
+            if (buffer.length >= 4 && buffer[0] == 28) {
                 proximity = true;           // Proximity event
-            } else if (buffer[0] == 29) {
+            } else if (buffer.length >= 4 && buffer[0] == 29) {
                 proximity = false;
             } else {
                 injectKeycode(buffer[0]);
@@ -130,10 +129,14 @@ public class EventController {
 //                        MotionEvent event = MotionEvent.obtain(lastMouseDown, now, action, 1, pointerProperties, pointerCoords, 0, button, 1f, 1f, 0, 0, InputDevice.SOURCE_TOUCHSCREEN, 0);
 //                        injectEvent(event);
 
-                // 为支持多点触控，新增 buffer[4] 这个字节
                 Point point = new Point(buffer[2], buffer[3]);
                 Point newpoint = device.NewgetPhysicalPoint(point);
-                injectTouch(action, buffer[4], newpoint, buffer[1]);
+                int pointerId = buffer.length >= 5 ? buffer[4] : 0;
+                if (action == MotionEvent.ACTION_DOWN) {
+                    Ln.i("inject touch DOWN " + newpoint.getX() + "," + newpoint.getY()
+                            + " displayId=" + device.getDisplayId());
+                }
+                injectTouch(action, pointerId, newpoint, buffer[1]);
             }
         }
     }

--- a/server/src/main/java/org/server/scrcpy/Ln.java
+++ b/server/src/main/java/org/server/scrcpy/Ln.java
@@ -24,6 +24,7 @@ public final class Ln {
         if (isEnabled(Level.DEBUG)) {
             Log.d(TAG, message);
             System.out.println("DEBUG: " + message);
+            System.out.flush();
         }
     }
 
@@ -31,6 +32,7 @@ public final class Ln {
         if (isEnabled(Level.INFO)) {
             Log.i(TAG, message);
             System.out.println("INFO: " + message);
+            System.out.flush();
         }
     }
 
@@ -38,6 +40,7 @@ public final class Ln {
         if (isEnabled(Level.WARN)) {
             Log.w(TAG, message);
             System.out.println("WARN: " + message);
+            System.out.flush();
         }
     }
 
@@ -46,6 +49,8 @@ public final class Ln {
             Log.e(TAG, message, throwable);
             System.out.println("ERROR: " + message);
             throwable.printStackTrace();
+            System.out.flush();
+            System.err.flush();
         }
     }
 
@@ -53,6 +58,7 @@ public final class Ln {
         if (isEnabled(Level.ERROR)) {
             Log.e(TAG, message);
             System.out.println("ERROR: " + message);
+            System.out.flush();
         }
     }
 

--- a/server/src/main/java/org/server/scrcpy/Options.java
+++ b/server/src/main/java/org/server/scrcpy/Options.java
@@ -2,12 +2,18 @@ package org.server.scrcpy;
 
 public class Options {
 
+    public static final String CODEC_H264 = "h264";
+    public static final String CODEC_H265 = "h265";
+    public static final String DEFAULT_ENCODER = "-";
+
     private String ip;
     private int maxSize;
     private int bitRate;
     private boolean tunnelForward;
-
     private boolean enableAudioForward = true;
+    private String videoCodec = CODEC_H264;
+    private String videoEncoder = DEFAULT_ENCODER;
+    private int frameRate = 60;
 
     public String getIp() {
         return ip;
@@ -49,11 +55,59 @@ public class Options {
         this.tunnelForward = tunnelForward;
     }
 
+    public String getVideoCodec() {
+        return videoCodec;
+    }
 
-    /***
-     * 从 args 中还原参数
-     * @param args
-     * @return
+    public void setVideoCodec(String videoCodec) {
+        this.videoCodec = normalizeCodec(videoCodec);
+    }
+
+    public String getVideoEncoder() {
+        return videoEncoder;
+    }
+
+    public void setVideoEncoder(String videoEncoder) {
+        if (videoEncoder == null || videoEncoder.isEmpty() || DEFAULT_ENCODER.equals(videoEncoder)) {
+            this.videoEncoder = DEFAULT_ENCODER;
+        } else {
+            this.videoEncoder = videoEncoder.trim();
+        }
+    }
+
+    public int getFrameRate() {
+        return frameRate;
+    }
+
+    public void setFrameRate(int frameRate) {
+        this.frameRate = frameRate > 0 ? frameRate : 60;
+    }
+
+    public String getVideoMimeType() {
+        return mimeForCodec(videoCodec);
+    }
+
+    public boolean hasCustomEncoder() {
+        return videoEncoder != null && !videoEncoder.isEmpty() && !DEFAULT_ENCODER.equals(videoEncoder);
+    }
+
+    public static String normalizeCodec(String codec) {
+        if (codec == null) {
+            return CODEC_H264;
+        }
+        String value = codec.trim().toLowerCase();
+        if ("h265".equals(value) || "hevc".equals(value)) {
+            return CODEC_H265;
+        }
+        return CODEC_H264;
+    }
+
+    public static String mimeForCodec(String codec) {
+        return CODEC_H265.equals(normalizeCodec(codec)) ? "video/hevc" : "video/avc";
+    }
+
+    /**
+     * Restore options from args. Extra args are optional for backward compatibility.
      */
     public static Options createOptions(String[] args) {
         Options options = new Options();
@@ -62,20 +116,28 @@ public class Options {
         options.bitRate = Integer.parseInt(args[2]);
         options.tunnelForward = Boolean.parseBoolean(args[3]);
         options.enableAudioForward = Boolean.parseBoolean(args[4]);
+        if (args.length > 5) {
+            options.setVideoCodec(args[5]);
+        }
+        if (args.length > 6) {
+            options.setVideoEncoder(args[6]);
+        }
+        if (args.length > 7) {
+            options.setFrameRate(Integer.parseInt(args[7]));
+        }
         return options;
     }
 
-    /**
-     * 将参数转为 args 传递给 scrcpy server
-     * @return
-     */
     public String[] optionsToArgs() {
         return new String[]{
                 ip,
                 Long.toString(maxSize),
                 Long.toString(bitRate),
                 String.valueOf(tunnelForward),
-                String.valueOf(enableAudioForward)
+                String.valueOf(enableAudioForward),
+                videoCodec,
+                hasCustomEncoder() ? videoEncoder : DEFAULT_ENCODER,
+                Integer.toString(frameRate)
         };
     }
 }

--- a/server/src/main/java/org/server/scrcpy/ScreenCapture.java
+++ b/server/src/main/java/org/server/scrcpy/ScreenCapture.java
@@ -4,7 +4,6 @@ import android.graphics.Rect;
 import android.hardware.display.VirtualDisplay;
 import android.os.Build;
 import android.os.IBinder;
-import android.util.Log;
 import android.view.Surface;
 
 import org.server.scrcpy.wrappers.ServiceManager;
@@ -22,11 +21,9 @@ public class ScreenCapture {
     }
 
     public void start(Surface surface) {
-        ScreenInfo screenInfo = device.getScreenInfo();
-
         Rect deviceRect = device.getScreenInfo().getDeviceSize().toRect();
         Rect videoRect = device.getScreenInfo().getVideoSize().toRect();
-
+        int layerStack = device.getLayerStack();
 
         if (display != null) {
             SurfaceControl.destroyDisplay(display);
@@ -37,16 +34,34 @@ public class ScreenCapture {
             virtualDisplay = null;
         }
 
+        // Come scrcpy ufficiale: su Android 14+ createDisplay non esiste più.
+        // Prima l'API nascosta DisplayManager.createVirtualDisplay(displayId),
+        // poi SurfaceControl, infine AUTO_MIRROR.
         try {
             virtualDisplay = ServiceManager.getDisplayManager()
-                    .createVirtualDisplay("scrcpy", videoRect.width(), videoRect.height(), 0, surface);
-            Ln.d("Display: using DisplayManager API");
+                    .createVirtualDisplay("scrcpy", videoRect.width(), videoRect.height(),
+                            device.getDisplayId(), surface);
+            Ln.i("Display: using DisplayManager API (mirror displayId=" + device.getDisplayId()
+                    + " " + videoRect.width() + "x" + videoRect.height() + ")");
+            return;
         } catch (Exception displayManagerException) {
+            Ln.e("DisplayManager capture failed, trying SurfaceControl", displayManagerException);
             try {
                 display = createDisplay();
-                setDisplaySurface(display, surface, deviceRect, videoRect);
+                setDisplaySurface(display, surface, deviceRect, videoRect, layerStack);
+                Ln.i("Display: using SurfaceControl API (layerStack=" + layerStack + ")");
+                return;
             } catch (Exception surfaceControlException) {
-                throw new AssertionError("Could not create display");
+                Ln.e("SurfaceControl capture failed, trying AUTO_MIRROR VirtualDisplay", surfaceControlException);
+                try {
+                    virtualDisplay = ServiceManager.getDisplayManager()
+                            .createMirrorVirtualDisplay("scrcpy", videoRect.width(), videoRect.height(),
+                                    device.getDensityDpi(), surface);
+                    Ln.i("Display: using AUTO_MIRROR VirtualDisplay dpi=" + device.getDensityDpi());
+                } catch (Exception mirrorException) {
+                    Ln.e("AUTO_MIRROR failed", mirrorException);
+                    throw new AssertionError("Could not create display");
+                }
             }
         }
     }
@@ -71,12 +86,12 @@ public class ScreenCapture {
         return SurfaceControl.createDisplay("scrcpy", secure);
     }
 
-    private static void setDisplaySurface(IBinder display, Surface surface, Rect deviceRect, Rect displayRect) {
+    private static void setDisplaySurface(IBinder display, Surface surface, Rect deviceRect, Rect displayRect, int layerStack) {
         SurfaceControl.openTransaction();
         try {
             SurfaceControl.setDisplaySurface(display, surface);
             SurfaceControl.setDisplayProjection(display, 0, deviceRect, displayRect);
-            SurfaceControl.setDisplayLayerStack(display, 0);
+            SurfaceControl.setDisplayLayerStack(display, layerStack);
         } finally {
             SurfaceControl.closeTransaction();
         }

--- a/server/src/main/java/org/server/scrcpy/ScreenEncoder.java
+++ b/server/src/main/java/org/server/scrcpy/ScreenEncoder.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.graphics.Rect;
 import android.media.MediaCodec;
 import android.media.MediaCodecInfo;
+import android.media.MediaCodecList;
 import android.media.MediaFormat;
 import android.os.Build;
 import android.os.Bundle;
@@ -21,12 +22,14 @@ import org.server.scrcpy.wrappers.SurfaceControl;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class ScreenEncoder implements Device.RotationListener {
 
     private static final int DEFAULT_FRAME_RATE = 60; // fps
-    private static final int DEFAULT_I_FRAME_INTERVAL = 10; // seconds
+    private static final int DEFAULT_I_FRAME_INTERVAL = 1; // seconds, lower = faster recovery
 
     private static final int REPEAT_FRAME_DELAY = 6; // repeat after 6 frames
 
@@ -41,6 +44,7 @@ public class ScreenEncoder implements Device.RotationListener {
     private int iFrameInterval;
     private String mimeType = "video/avc";
     private String encoderName = "";
+    private String lastGoodEncoder = "";
 
     public ScreenEncoder(int bitRate, int frameRate, int iFrameInterval) {
         this(bitRate, frameRate, iFrameInterval, "video/avc", "");
@@ -64,6 +68,55 @@ public class ScreenEncoder implements Device.RotationListener {
                 options.hasCustomEncoder() ? options.getVideoEncoder() : "");
     }
 
+    private static boolean isUnreliableEncoder(String encoderName) {
+        if (encoderName == null) {
+            return false;
+        }
+        String name = encoderName.toLowerCase();
+        // c2.v4l2.* su alcuni SoC accetta configure/start ma non emette mai frame.
+        return name.contains("v4l2");
+    }
+
+    private static boolean isSoftwareEncoder(MediaCodecInfo info, String name) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            try {
+                return info.isSoftwareOnly();
+            } catch (Throwable ignored) {
+            }
+        }
+        String n = name.toLowerCase();
+        return n.contains("android") || n.contains("google") || n.contains(".sw.");
+    }
+
+    private static boolean supportsMime(MediaCodecInfo info, String mime) {
+        String[] types = info.getSupportedTypes();
+        if (types == null) {
+            return false;
+        }
+        for (String type : types) {
+            if (mime.equalsIgnoreCase(type)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<String> listEncoders(boolean software) {
+        List<String> names = new ArrayList<>();
+        MediaCodecInfo[] codecs = new MediaCodecList(MediaCodecList.REGULAR_CODECS).getCodecInfos();
+        for (MediaCodecInfo info : codecs) {
+            if (info == null || !info.isEncoder() || !supportsMime(info, mimeType)) {
+                continue;
+            }
+            String name = info.getName();
+            if (isUnreliableEncoder(name) || isSoftwareEncoder(info, name) != software) {
+                continue;
+            }
+            names.add(name);
+        }
+        return names;
+    }
+
     private static String normalizeEncoderName(String encoderName) {
         if (encoderName == null) {
             return "";
@@ -77,31 +130,58 @@ public class ScreenEncoder implements Device.RotationListener {
 
     private MediaCodec createCodec(int attempt) throws IOException {
         Exception last = null;
-        boolean hevc = "video/hevc".equals(mimeType);
-        String[] fallbacks;
-        if (attempt == 0) {
-            fallbacks = hevc
-                    ? new String[]{encoderName, null, "c2.android.hevc.encoder", "OMX.google.hevc.encoder"}
-                    : new String[]{encoderName, null, "c2.android.avc.encoder", "OMX.google.h264.encoder"};
-        } else {
-            fallbacks = hevc
-                    ? new String[]{"c2.android.hevc.encoder", "OMX.google.hevc.encoder", null}
-                    : new String[]{"c2.android.avc.encoder", "OMX.google.h264.encoder", null};
+        List<String> hw = listEncoders(false);
+        List<String> sw = listEncoders(true);
+        if (attempt == 0 && lastGoodEncoder.isEmpty()) {
+            Ln.i("HW encoders: " + hw);
+            Ln.i("SW encoders: " + sw);
         }
+        List<String> fallbacks = new ArrayList<>();
+        if (attempt == 0) {
+            if (!encoderName.isEmpty()) {
+                fallbacks.add(encoderName);
+            }
+            if (!lastGoodEncoder.isEmpty() && !fallbacks.contains(lastGoodEncoder)) {
+                fallbacks.add(lastGoodEncoder);
+            }
+            for (String name : hw) {
+                if (!fallbacks.contains(name)) {
+                    fallbacks.add(name);
+                }
+            }
+            for (String name : sw) {
+                if (!fallbacks.contains(name)) {
+                    fallbacks.add(name);
+                }
+            }
+        } else {
+            fallbacks.addAll(sw);
+            if ("video/hevc".equals(mimeType)) {
+                fallbacks.add("c2.android.hevc.encoder");
+                fallbacks.add("OMX.google.hevc.encoder");
+            } else {
+                fallbacks.add("c2.android.avc.encoder");
+                fallbacks.add("OMX.google.h264.encoder");
+            }
+        }
+
         for (String name : fallbacks) {
-            if (name != null && name.isEmpty()) {
+            if (name == null || name.isEmpty()) {
                 continue;
             }
             try {
-                MediaCodec codec;
-                if (name == null) {
-                    Ln.i("Using video codec mime: " + mimeType);
-                    codec = MediaCodec.createEncoderByType(mimeType);
-                } else {
-                    Ln.i("Trying video encoder: " + name);
-                    codec = MediaCodec.createByCodecName(name);
+                Ln.i("Trying video encoder: " + name);
+                MediaCodec codec = MediaCodec.createByCodecName(name);
+                String actualName = codec.getName();
+                if (isUnreliableEncoder(actualName) && !actualName.equalsIgnoreCase(encoderName)) {
+                    Ln.w("Skipping unreliable video encoder: " + actualName);
+                    try {
+                        codec.release();
+                    } catch (Exception ignored) {
+                    }
+                    continue;
                 }
-                Ln.i("Video encoder ready: " + codec.getName());
+                Ln.i("Video encoder ready: " + actualName);
                 return codec;
             } catch (Exception e) {
                 Ln.e("Encoder candidate failed: " + name, e);
@@ -130,6 +210,12 @@ public class ScreenEncoder implements Device.RotationListener {
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             format.setInteger(MediaFormat.KEY_LATENCY, 1);
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            format.setInteger(MediaFormat.KEY_OPERATING_RATE, frameRate);
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            format.setInteger(MediaFormat.KEY_LOW_LATENCY, 1);
         }
         format.setLong(MediaFormat.KEY_REPEAT_PREVIOUS_FRAME_AFTER, 100_000);
         return format;
@@ -309,16 +395,21 @@ public class ScreenEncoder implements Device.RotationListener {
     @SuppressLint("NewApi")
     private boolean encode(MediaCodec codec, OutputStream outputStream) throws IOException {
         @SuppressWarnings("checkstyle:MagicNumber")
-//        byte[] buf = new byte[bitRate / 8]; // may contain up to 1 second of video
         boolean eof = false;
+        boolean gotFrame = false;
         int noFrameCount = 0;
         MediaCodec.BufferInfo bufferInfo = new MediaCodec.BufferInfo();
         while (!consumeRotationChange() && !eof) {
-            int outputBufferId = codec.dequeueOutputBuffer(bufferInfo, 1_000_000);
+            // Dopo il primo frame non uccidere l'encoder se lo schermo è fermo:
+            // REPEAT_FRAME può non arrivare e un timeout corto causa restart + lag.
+            int timeoutUs = gotFrame ? 100_000 : 1_000_000;
+            int outputBufferId = codec.dequeueOutputBuffer(bufferInfo, timeoutUs);
             if (outputBufferId == MediaCodec.INFO_TRY_AGAIN_LATER) {
-                noFrameCount++;
-                if (noFrameCount > 8) {
-                    throw new IllegalStateException("Encoder produced no frames");
+                if (!gotFrame) {
+                    noFrameCount++;
+                    if (noFrameCount > 6) {
+                        throw new IllegalStateException("Encoder produced no frames");
+                    }
                 }
                 continue;
             }
@@ -341,6 +432,8 @@ public class ScreenEncoder implements Device.RotationListener {
                     outputBuffer = codec.getOutputBuffer(outputBufferId);
 
                     if (bufferInfo.size > 0 && outputBuffer != null) {
+                        gotFrame = true;
+                        lastGoodEncoder = codec.getName();
                         outputBuffer.position(bufferInfo.offset);
                         outputBuffer.limit(bufferInfo.offset + bufferInfo.size);
                         byte[] b = new byte[outputBuffer.remaining()];

--- a/server/src/main/java/org/server/scrcpy/ScreenEncoder.java
+++ b/server/src/main/java/org/server/scrcpy/ScreenEncoder.java
@@ -39,35 +39,103 @@ public class ScreenEncoder implements Device.RotationListener {
     private int bitRate;
     private int frameRate;
     private int iFrameInterval;
+    private String mimeType = "video/avc";
+    private String encoderName = "";
 
     public ScreenEncoder(int bitRate, int frameRate, int iFrameInterval) {
+        this(bitRate, frameRate, iFrameInterval, "video/avc", "");
+    }
+
+    public ScreenEncoder(int bitRate, int frameRate, int iFrameInterval, String mimeType, String encoderName) {
         this.bitRate = bitRate;
-        this.frameRate = frameRate;
+        this.frameRate = frameRate > 0 ? frameRate : DEFAULT_FRAME_RATE;
         this.iFrameInterval = iFrameInterval;
+        this.mimeType = mimeType == null || mimeType.isEmpty() ? "video/avc" : mimeType;
+        this.encoderName = normalizeEncoderName(encoderName);
     }
 
     public ScreenEncoder(int bitRate) {
         this(bitRate, DEFAULT_FRAME_RATE, DEFAULT_I_FRAME_INTERVAL);
     }
 
-    private static MediaCodec createCodec() throws IOException {
-        return MediaCodec.createEncoderByType("video/avc");
+    public ScreenEncoder(Options options) {
+        this(options.getBitRate(), options.getFrameRate(), DEFAULT_I_FRAME_INTERVAL,
+                options.getVideoMimeType(),
+                options.hasCustomEncoder() ? options.getVideoEncoder() : "");
     }
 
-    private static MediaFormat createFormat(int bitRate, int frameRate, int iFrameInterval) throws IOException {
+    private static String normalizeEncoderName(String encoderName) {
+        if (encoderName == null) {
+            return "";
+        }
+        String name = encoderName.trim();
+        if (name.isEmpty() || Options.DEFAULT_ENCODER.equals(name)) {
+            return "";
+        }
+        return name;
+    }
+
+    private MediaCodec createCodec(int attempt) throws IOException {
+        Exception last = null;
+        boolean hevc = "video/hevc".equals(mimeType);
+        String[] fallbacks;
+        if (attempt == 0) {
+            fallbacks = hevc
+                    ? new String[]{encoderName, null, "c2.android.hevc.encoder", "OMX.google.hevc.encoder"}
+                    : new String[]{encoderName, null, "c2.android.avc.encoder", "OMX.google.h264.encoder"};
+        } else {
+            fallbacks = hevc
+                    ? new String[]{"c2.android.hevc.encoder", "OMX.google.hevc.encoder", null}
+                    : new String[]{"c2.android.avc.encoder", "OMX.google.h264.encoder", null};
+        }
+        for (String name : fallbacks) {
+            if (name != null && name.isEmpty()) {
+                continue;
+            }
+            try {
+                MediaCodec codec;
+                if (name == null) {
+                    Ln.i("Using video codec mime: " + mimeType);
+                    codec = MediaCodec.createEncoderByType(mimeType);
+                } else {
+                    Ln.i("Trying video encoder: " + name);
+                    codec = MediaCodec.createByCodecName(name);
+                }
+                Ln.i("Video encoder ready: " + codec.getName());
+                return codec;
+            } catch (Exception e) {
+                Ln.e("Encoder candidate failed: " + name, e);
+                last = e;
+            }
+        }
+        if (last instanceof IOException) {
+            throw (IOException) last;
+        }
+        throw new IOException("No video encoder available for " + mimeType, last);
+    }
+
+    private MediaFormat createFormat(int bitRate, int frameRate, int iFrameInterval) {
         MediaFormat format = new MediaFormat();
-        format.setString(MediaFormat.KEY_MIME, "video/avc");
+        format.setString(MediaFormat.KEY_MIME, mimeType);
         format.setInteger(MediaFormat.KEY_BIT_RATE, bitRate);
         format.setInteger(MediaFormat.KEY_FRAME_RATE, frameRate);
         format.setInteger(MediaFormat.KEY_COLOR_FORMAT, MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface);
         format.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, iFrameInterval);
-
-        // display the very first frame, and recover from bad quality when no new frames
-        format.setLong(MediaFormat.KEY_REPEAT_PREVIOUS_FRAME_AFTER, MICROSECONDS_IN_ONE_SECOND * REPEAT_FRAME_DELAY / frameRate); // µs
+        format.setInteger("max-bframes", 0);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            format.setInteger(MediaFormat.KEY_COLOR_RANGE, MediaFormat.COLOR_RANGE_LIMITED);
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            format.setInteger(MediaFormat.KEY_PRIORITY, 0);
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            format.setInteger(MediaFormat.KEY_LATENCY, 1);
+        }
+        format.setLong(MediaFormat.KEY_REPEAT_PREVIOUS_FRAME_AFTER, 100_000);
         return format;
     }
 
-    private static IBinder createDisplay() {
+    private static IBinder createDisplay() throws Exception {
         // Since Android 12 (preview), secure displays could not be created with shell permissions anymore.
         // On Android 12 preview, SDK_INT is still R (not S), but CODENAME is "S".
         boolean secure = Build.VERSION.SDK_INT < Build.VERSION_CODES.R || (Build.VERSION.SDK_INT == Build.VERSION_CODES.R && !"S".equals(
@@ -137,8 +205,13 @@ public class ScreenEncoder implements Device.RotationListener {
 
     public void streamScreen(Options options, Device device, OutputStream outputStream) throws IOException {
         // Log.d("ScreenCapture", buildDisplayListMessage());
-        int[] buf = new int[]{device.getScreenInfo().getDeviceSize().getWidth(), device.getScreenInfo().getDeviceSize().getHeight()};
-        final byte[] array = new byte[buf.length * 4];   // https://stackoverflow.com/questions/2183240/java-integer-to-byte-array
+        Size deviceSize = device.getScreenInfo().getDeviceSize();
+        Size videoSize = device.getScreenInfo().getVideoSize();
+        int[] buf = new int[]{
+                deviceSize.getWidth(), deviceSize.getHeight(),
+                videoSize.getWidth(), videoSize.getHeight()
+        };
+        final byte[] array = new byte[buf.length * 4];
         for (int j = 0; j < buf.length; j++) {
             final int c = buf[j];
             array[j * 4] = (byte) ((c & 0xFF000000) >> 24);
@@ -146,7 +219,11 @@ public class ScreenEncoder implements Device.RotationListener {
             array[j * 4 + 2] = (byte) ((c & 0xFF00) >> 8);
             array[j * 4 + 3] = (byte) (c & 0xFF);
         }
-        outputStream.write(array, 0, array.length);   // Sending device resolution
+        outputStream.write(array, 0, array.length);
+        outputStream.flush();
+        Ln.i("Sent device resolution " + buf[0] + "x" + buf[1]
+                + " video=" + buf[2] + "x" + buf[3]
+                + " mime=" + mimeType + " encoder=" + (encoderName.isEmpty() ? "default" : encoderName));
 
         if(options.isEnableAudioForward()){
             startAudioCapture(outputStream);  // start audio capture
@@ -159,7 +236,7 @@ public class ScreenEncoder implements Device.RotationListener {
         ScreenCapture capture = new ScreenCapture(device);
         try {
             do {
-                MediaCodec codec = createCodec();
+                MediaCodec codec = createCodec(errorCount);
 //                IBinder display = createDisplay();
 //                Rect deviceRect = device.getScreenInfo().getDeviceSize().toRect();
                 Rect videoRect = device.getScreenInfo().getVideoSize().toRect();
@@ -187,9 +264,14 @@ public class ScreenEncoder implements Device.RotationListener {
                     alive = true;
                 } finally {
                     Log.d("ScreenCapture", "帧处理 finally 退出了");
-                    codec.stop();
-                    // destroyDisplay(display);
-                    codec.release();
+                    try {
+                        codec.stop();
+                    } catch (Exception ignored) {
+                    }
+                    try {
+                        codec.release();
+                    } catch (Exception ignored) {
+                    }
                     if (surface != null) {
                         surface.release();
                     }
@@ -229,9 +311,18 @@ public class ScreenEncoder implements Device.RotationListener {
         @SuppressWarnings("checkstyle:MagicNumber")
 //        byte[] buf = new byte[bitRate / 8]; // may contain up to 1 second of video
         boolean eof = false;
+        int noFrameCount = 0;
         MediaCodec.BufferInfo bufferInfo = new MediaCodec.BufferInfo();
         while (!consumeRotationChange() && !eof) {
-            int outputBufferId = codec.dequeueOutputBuffer(bufferInfo, -1);
+            int outputBufferId = codec.dequeueOutputBuffer(bufferInfo, 1_000_000);
+            if (outputBufferId == MediaCodec.INFO_TRY_AGAIN_LATER) {
+                noFrameCount++;
+                if (noFrameCount > 8) {
+                    throw new IllegalStateException("Encoder produced no frames");
+                }
+                continue;
+            }
+            noFrameCount = 0;
             eof = (bufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0;
             try {
                 if (consumeRotationChange()) {

--- a/server/src/main/java/org/server/scrcpy/Server.java
+++ b/server/src/main/java/org/server/scrcpy/Server.java
@@ -15,9 +15,10 @@ public final class Server {
     private static void scrcpy(Options options) throws IOException {
         Workarounds.apply();  // init content
 
+        ip = options.getIp();
         final Device device = new Device(options);
         try (DroidConnection connection = DroidConnection.open(ip)) {
-            ScreenEncoder screenEncoder = new ScreenEncoder(options.getBitRate());
+            ScreenEncoder screenEncoder = new ScreenEncoder(options);
 
             // asynchronous
             startEventController(device, connection, screenEncoder);

--- a/server/src/main/java/org/server/scrcpy/Size.java
+++ b/server/src/main/java/org/server/scrcpy/Size.java
@@ -26,6 +26,39 @@ public final class Size {
         return new Size(height, width);
     }
 
+    /**
+     * Scala per entrare in maxSize (lato maggiore) conservando l'aspect, poi arrotonda a multiplo di 8.
+     * maxSize &lt;= 0 = risoluzione nativa del device.
+     */
+    public Size scaleTo(int maxSize) {
+        int w = width;
+        int h = height;
+        if (maxSize > 0) {
+            if (w >= h) {
+                if (w > maxSize) {
+                    h = (int) ((long) h * maxSize / w);
+                    w = maxSize;
+                }
+            } else if (h > maxSize) {
+                w = (int) ((long) w * maxSize / h);
+                h = maxSize;
+            }
+        }
+        w = round8(w);
+        h = round8(h);
+        if (w < 8) {
+            w = 8;
+        }
+        if (h < 8) {
+            h = 8;
+        }
+        return new Size(w, h);
+    }
+
+    private static int round8(int value) {
+        return (value + 4) & ~7;
+    }
+
     public Rect toRect() {
         return new Rect(0, 0, width, height);
     }

--- a/server/src/main/java/org/server/scrcpy/wrappers/DisplayManager.java
+++ b/server/src/main/java/org/server/scrcpy/wrappers/DisplayManager.java
@@ -100,7 +100,12 @@ public final class DisplayManager {
             int rotation = cls.getDeclaredField("rotation").getInt(displayInfo);
             int layerStack = cls.getDeclaredField("layerStack").getInt(displayInfo);
             int flags = cls.getDeclaredField("flags").getInt(displayInfo);
-            return new DisplayInfo(displayId, new Size(width, height), rotation, layerStack, flags);
+            int densityDpi = 160;
+            try {
+                densityDpi = cls.getDeclaredField("logicalDensityDpi").getInt(displayInfo);
+            } catch (Exception ignored) {
+            }
+            return new DisplayInfo(displayId, new Size(width, height), rotation, layerStack, flags, densityDpi);
         } catch (ReflectiveOperationException e) {
             throw new AssertionError(e);
         }
@@ -124,5 +129,24 @@ public final class DisplayManager {
     public VirtualDisplay createVirtualDisplay(String name, int width, int height, int displayIdToMirror, Surface surface) throws Exception {
         Method method = getCreateVirtualDisplayMethod();
         return (VirtualDisplay) method.invoke(null, name, width, height, displayIdToMirror, surface);
+    }
+
+    public VirtualDisplay createNewVirtualDisplay(String name, int width, int height, int dpi, Surface surface, int flags) throws Exception {
+        java.lang.reflect.Constructor<android.hardware.display.DisplayManager> ctor =
+                android.hardware.display.DisplayManager.class.getDeclaredConstructor(android.content.Context.class);
+        ctor.setAccessible(true);
+        android.hardware.display.DisplayManager dm = ctor.newInstance(org.server.scrcpy.util.FakeContext.get());
+        return dm.createVirtualDisplay(name, width, height, dpi, surface, flags);
+    }
+
+    public VirtualDisplay createMirrorVirtualDisplay(String name, int width, int height, int dpi, Surface surface) throws Exception {
+        int density = dpi > 0 ? dpi : 160;
+        Ln.i("Creating AUTO_MIRROR VirtualDisplay dpi=" + density + " " + width + "x" + height);
+        try {
+            return createNewVirtualDisplay(name, width, height, density, surface, 0x00000010);
+        } catch (Exception e) {
+            Ln.e("AUTO_MIRROR VirtualDisplay failed, trying PUBLIC|AUTO_MIRROR", e);
+            return createNewVirtualDisplay(name, width, height, density, surface, 0x00000001 | 0x00000010);
+        }
     }
 }

--- a/server/src/main/java/org/server/scrcpy/wrappers/InputManager.java
+++ b/server/src/main/java/org/server/scrcpy/wrappers/InputManager.java
@@ -3,6 +3,8 @@ package org.server.scrcpy.wrappers;
 import android.os.IInterface;
 import android.view.InputEvent;
 
+import org.server.scrcpy.Ln;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
@@ -24,11 +26,27 @@ public final class InputManager {
         }
     }
 
+    public static boolean setDisplayId(InputEvent event, int displayId) {
+        try {
+            Method method = InputEvent.class.getMethod("setDisplayId", int.class);
+            method.invoke(event, displayId);
+            return true;
+        } catch (NoSuchMethodException e) {
+            return true;
+        } catch (Exception e) {
+            Ln.e("Could not set displayId on input event", e);
+            return false;
+        }
+    }
+
     public boolean injectInputEvent(InputEvent inputEvent, int mode) {
         try {
             return (Boolean) injectInputEventMethod.invoke(manager, inputEvent, mode);
-        } catch (InvocationTargetException | IllegalAccessException e) {
-            // throw new AssertionError(e);
+        } catch (InvocationTargetException e) {
+            Ln.e("injectInputEvent failed", e.getCause() != null ? e.getCause() : e);
+            return false;
+        } catch (IllegalAccessException e) {
+            Ln.e("injectInputEvent failed", e);
             return false;
         }
     }

--- a/server/src/main/java/org/server/scrcpy/wrappers/SurfaceControl.java
+++ b/server/src/main/java/org/server/scrcpy/wrappers/SurfaceControl.java
@@ -64,12 +64,8 @@ public final class SurfaceControl {
         }
     }
 
-    public static IBinder createDisplay(String name, boolean secure) {
-        try {
-            return (IBinder) CLASS.getMethod("createDisplay", String.class, boolean.class).invoke(null, name, secure);
-        } catch (Exception e) {
-            throw new AssertionError(e);
-        }
+    public static IBinder createDisplay(String name, boolean secure) throws Exception {
+        return (IBinder) CLASS.getMethod("createDisplay", String.class, boolean.class).invoke(null, name, secure);
     }
 
     public static void destroyDisplay(IBinder displayToken) {


### PR DESCRIPTION
## Summary
- Fix black screen / surface timing issues and stop encoder restart lag; improve Android 14+ mirroring with scaled touch mapping and encoder fallback
- Add Auto resolution (min of local and remote display), rotated mirror view, online/offline status LED
- Add ADB reboot and power-off buttons on the main screen, plus power key on the mirror nav bar

## Test plan
- [ ] Connect to a remote device over ADB wireless and verify mirroring starts without black screen
- [ ] Toggle Auto resolution and confirm stream size matches local/remote limits
- [ ] Enable bottom nav controls and verify Back / Home / App switch / Power key events
- [ ] From the home screen, confirm ADB Reboot and ADB Power off dialogs and commands
- [ ] Rotate during a session and verify the mirror layout updates correctly
